### PR TITLE
Add files from root folder to the distribution

### DIFF
--- a/installers/linux/universal/tar/build.gradle
+++ b/installers/linux/universal/tar/build.gradle
@@ -55,7 +55,7 @@ task copySource(type: Exec) {
             "${project.rootDir}/", buildRoot
 }
 
-/** 
+/**
  * Scan the patches folder for any .patch that needs
  * to be applied before start building.
  */
@@ -122,6 +122,7 @@ task packageBuildResults(type: Tar) {
         include 'LICENSE'
         include 'README.md'
         include 'version.txt'
+        into project.correttoJdkArchiveName
     }
     from(jdkResultingImage) {
         include 'bin/**'


### PR DESCRIPTION
This bring over a follow-up fix from Corretto-11 and the legal file permission changes.

https://github.com/corretto/corretto-11/commit/33797da9004671bafc2f6b2d1ce2a549302393c7