### PR TITLE
Debug zipped

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -93,7 +93,7 @@ allprojects {
         switch(project.findProperty("corretto.debug_level")) {
             case null:
             case "release":
-                correttoCommonFlags += ['--with-debug-level=release', '--with-native-debug-symbols=none']
+                correttoCommonFlags += ['--with-debug-level=release', '--with-native-debug-symbols=zipped']
                 break
             case "fastdebug":
                 correttoDebugLevel = "fastdebug"

--- a/build.gradle
+++ b/build.gradle
@@ -176,6 +176,7 @@ allprojects {
             correttoJdkArchiveName =
                     "amazon-corretto-${project.version.full}-${os}-${correttoArch}-${correttoDebugLevel}".toString()
         }
+        correttoDebugSymbolsArchiveName = "amazon-corretto-debugsymbols-${project.version.full}-${os}-${correttoArch}".toString()
         correttoTestImageArchiveName = "amazon-corretto-testimage-${project.version.full}-${os}-${correttoArch}".toString()
     }
 }

--- a/installers/linux/alpine/tar/build.gradle
+++ b/installers/linux/alpine/tar/build.gradle
@@ -118,12 +118,22 @@ task packageTestImage(type: Tar) {
         include '**'
     }
     into "amazon-corretto-testimage-${project.version.full}-alpine-linux-${arch_alias}"
+}
 
+task packageDebugSymbols(type: Tar) {
+    dependsOn packageTestImage
+    description 'Package debug symbols'
+    archiveName "amazon-corretto-debugsymbols-${project.version.full}-alpine-linux-${arch_alias}.tar.gz"
+    compression Compression.GZIP
+    from(jdkResultingImage) {
+        include 'bin/*.diz'
+    }
+    into "amazon-corretto-testimage-${project.version.full}-alpine-linux-${arch_alias}"
 }
 
 task packageBuildResults(type: Tar) {
     description 'Compresses the JDK image and puts the results in build/distributions.'
-    dependsOn packageTestImage
+    dependsOn packageDebugSymbols
     dependsOn executeBuild
     archiveName "amazon-corretto-${project.version.full}-alpine-linux-${arch_alias}.tar.gz"
     compression Compression.GZIP
@@ -136,6 +146,7 @@ task packageBuildResults(type: Tar) {
     }
     from(jdkResultingImage) {
         include 'bin/**'
+        exclude 'bin/*.diz'
         include 'conf/**'
         include 'include/**'
         include 'jmods/**'

--- a/installers/linux/alpine/tar/build.gradle
+++ b/installers/linux/alpine/tar/build.gradle
@@ -128,7 +128,7 @@ task packageDebugSymbols(type: Tar) {
     from(jdkResultingImage) {
         include 'bin/*.diz'
     }
-    into "amazon-corretto-testimage-${project.version.full}-alpine-linux-${arch_alias}"
+    into "amazon-corretto-debugsymbols-${project.version.full}-alpine-linux-${arch_alias}"
 }
 
 task packageBuildResults(type: Tar) {

--- a/installers/linux/universal/tar/build.gradle
+++ b/installers/linux/universal/tar/build.gradle
@@ -108,12 +108,38 @@ task packageTestImage(type: Tar) {
         include '**'
     }
     into project.correttoTestImageArchiveName
+}
 
+task packageDebugImage(type: Tar) {
+    description 'Package debug results'
+    dependsOn packageTestImage
+    archiveName "${project.correttoJdkArchiveName}-debug.tar.gz"
+    compression Compression.GZIP
+    from(buildRoot) {
+        include 'ADDITIONAL_LICENSE_INFO'
+        include 'ASSEMBLY_EXCEPTION'
+        include 'LICENSE'
+        include 'README.md'
+        include 'version.txt'
+        into project.correttoJdkArchiveName
+    }
+    from(jdkResultingImage) {
+        include 'bin/*.diz'
+        into project.correttoJdkArchiveName
+    }
+
+    // Copy legal directory specifically to set permission correctly.
+    // See https://github.com/corretto/corretto-11/issues/129
+    from("${jdkResultingImage}/legal") {
+        include '**'
+        fileMode 0444
+        into "${project.correttoJdkArchiveName}/legal"
+    }
 }
 
 task packageBuildResults(type: Tar) {
     description 'Compresses the JDK image and puts the results in build/distributions.'
-    dependsOn packageTestImage
+    dependsOn packageDebugImage
     archiveName "${project.correttoJdkArchiveName}.tar.gz"
     compression Compression.GZIP
     from(buildRoot) {
@@ -126,6 +152,7 @@ task packageBuildResults(type: Tar) {
     }
     from(jdkResultingImage) {
         include 'bin/**'
+        exclude 'bin/*.diz'
         include 'conf/**'
         include 'include/**'
         include 'jmods/**'

--- a/installers/linux/universal/tar/build.gradle
+++ b/installers/linux/universal/tar/build.gradle
@@ -110,7 +110,7 @@ task packageTestImage(type: Tar) {
     into project.correttoTestImageArchiveName
 }
 
-task packageDebugImage(type: Tar) {
+task packageDebugSymbols(type: Tar) {
     description 'Package debug results'
     dependsOn packageTestImage
     archiveName "${project.correttoDebugSymbolsArchiveName}.tar.gz"
@@ -139,7 +139,7 @@ task packageDebugImage(type: Tar) {
 
 task packageBuildResults(type: Tar) {
     description 'Compresses the JDK image and puts the results in build/distributions.'
-    dependsOn packageDebugImage
+    dependsOn packageDebugSymbols
     archiveName "${project.correttoJdkArchiveName}.tar.gz"
     compression Compression.GZIP
     from(buildRoot) {

--- a/installers/linux/universal/tar/build.gradle
+++ b/installers/linux/universal/tar/build.gradle
@@ -115,25 +115,9 @@ task packageDebugSymbols(type: Tar) {
     dependsOn packageTestImage
     archiveName "${project.correttoDebugSymbolsArchiveName}.tar.gz"
     compression Compression.GZIP
-    from(buildRoot) {
-        include 'ADDITIONAL_LICENSE_INFO'
-        include 'ASSEMBLY_EXCEPTION'
-        include 'LICENSE'
-        include 'README.md'
-        include 'version.txt'
-        into project.correttoDebugSymbolsArchiveName
-    }
     from(jdkResultingImage) {
         include 'bin/*.diz'
         into project.correttoDebugSymbolsArchiveName
-    }
-
-    // Copy legal directory specifically to set permission correctly.
-    // See https://github.com/corretto/corretto-11/issues/129
-    from("${jdkResultingImage}/legal") {
-        include '**'
-        fileMode 0444
-        into "${project.correttoDebugSymbolsArchiveName}/legal"
     }
 }
 

--- a/installers/linux/universal/tar/build.gradle
+++ b/installers/linux/universal/tar/build.gradle
@@ -113,7 +113,7 @@ task packageTestImage(type: Tar) {
 task packageDebugImage(type: Tar) {
     description 'Package debug results'
     dependsOn packageTestImage
-    archiveName "${project.correttoJdkArchiveName}-debug.tar.gz"
+    archiveName "${project.correttoDebugSymbolsArchiveName}.tar.gz"
     compression Compression.GZIP
     from(buildRoot) {
         include 'ADDITIONAL_LICENSE_INFO'
@@ -121,11 +121,11 @@ task packageDebugImage(type: Tar) {
         include 'LICENSE'
         include 'README.md'
         include 'version.txt'
-        into project.correttoJdkArchiveName
+        into project.correttoDebugSymbolsArchiveName
     }
     from(jdkResultingImage) {
         include 'bin/*.diz'
-        into project.correttoJdkArchiveName
+        into project.correttoDebugSymbolsArchiveName
     }
 
     // Copy legal directory specifically to set permission correctly.
@@ -133,7 +133,7 @@ task packageDebugImage(type: Tar) {
     from("${jdkResultingImage}/legal") {
         include '**'
         fileMode 0444
-        into "${project.correttoJdkArchiveName}/legal"
+        into "${project.correttoDebugSymbolsArchiveName}/legal"
     }
 }
 

--- a/installers/mac/tar/build.gradle
+++ b/installers/mac/tar/build.gradle
@@ -122,6 +122,7 @@ task prepareArtifacts {
         copy {
             from("${jdkResultingImage}/${correttoMacDir}") {
                 include "Contents/Home/bin/**"
+                exclude "Contents/Home/bin/*.diz"
                 include "Contents/Home/conf/**"
                 include "Contents/Home/include/**"
                 include "Contents/Home/jmods/**"
@@ -154,6 +155,18 @@ task packaging(type: Exec) {
     outputs.file tarDir
 }
 
+task packageDebugSymbols(type: Tar) {
+    dependsOn prepareArtifacts
+    description 'Package debug symbols'
+    archiveName "${project.correttoDebugSymbolsArchiveName}.tar.gz"
+    compression Compression.GZIP
+    from("${jdkResultingImage}/${correttoMacDir}") {
+        include "Contents/Home/bin/*.diz"
+    }
+    into "${buildDir}/${correttoMacDir}"
+    into project.correttoDebugSymbolsArchiveName
+}
+
 task packageTestResults(type: Tar) {
     dependsOn executeTestBuild
     description 'Package test results'
@@ -163,10 +176,10 @@ task packageTestResults(type: Tar) {
         include '**'
     }
     into project.correttoTestImageArchiveName
-
 }
 
 build.dependsOn packaging
+build.dependsOn packageDebugSymbols
 build.dependsOn packageTestResults
 
 artifacts {

--- a/installers/windows/zip/build.gradle
+++ b/installers/windows/zip/build.gradle
@@ -83,13 +83,6 @@ task packageDebugSymbols(type: Zip) {
     from("${copyImage.destinationDir}/jdk") {
         include 'bin/*.diz'
     }
-    from(buildRoot) {
-        include 'ASSEMBLY_EXCEPTION'
-        include 'LICENSE'
-        include 'version.txt'
-        include 'ADDITIONAL_LICENSE_INFO'
-        include 'README'
-    }
 }
 
 task packageBuildResults(type: Zip) {

--- a/installers/windows/zip/build.gradle
+++ b/installers/windows/zip/build.gradle
@@ -78,7 +78,7 @@ task packageTestImage(type: Zip) {
 
 task packageDebugSymbols(type: Zip) {
     dependsOn packageTestImage
-    archiveName "${project.correttoDebugSymbolsImageArchiveName}.zip"
+    archiveName "${project.correttoDebugSymbolsArchiveName}.zip"
 
     from("${copyImage.destinationDir}/jdk") {
         include 'bin/*.diz'

--- a/installers/windows/zip/build.gradle
+++ b/installers/windows/zip/build.gradle
@@ -76,12 +76,29 @@ task packageTestImage(type: Zip) {
     into project.correttoTestImageArchiveName
 }
 
-task packageBuildResults(type: Zip) {
+task packageDebugSymbols(type: Zip) {
     dependsOn packageTestImage
+    archiveName "${project.correttoDebugSymbolsImageArchiveName}.zip"
+
+    from("${copyImage.destinationDir}/jdk") {
+        include 'bin/*.diz'
+    }
+    from(buildRoot) {
+        include 'ASSEMBLY_EXCEPTION'
+        include 'LICENSE'
+        include 'version.txt'
+        include 'ADDITIONAL_LICENSE_INFO'
+        include 'README'
+    }
+}
+
+task packageBuildResults(type: Zip) {
+    dependsOn packageDebugSymbols
     archiveName  = "unsigned-jdk-image.zip"
 
     from("${copyImage.destinationDir}/jdk") {
         exclude 'demo'
+        exclude 'bin/*.diz'
     }
     from(buildRoot) {
         include 'ASSEMBLY_EXCEPTION'


### PR DESCRIPTION
## Description

Update gradle build scripts to build a separate linux/mac tar and windows zip for debug symbols. In this change, the default `release` build will produce debug symbols, but the symbols are not included in the original tar/zip. Tested on Windows, Linux, Mac x86.