### PR TITLE
Separate lib debug symbols into separate tar/zip.

### DIFF
--- a/installers/linux/alpine/tar/build.gradle
+++ b/installers/linux/alpine/tar/build.gradle
@@ -126,9 +126,9 @@ task packageDebugSymbols(type: Tar) {
     archiveName "amazon-corretto-debugsymbols-${project.version.full}-alpine-linux-${arch_alias}.tar.gz"
     compression Compression.GZIP
     from(jdkResultingImage) {
-        include 'bin/*.diz'
+        include '**/*.diz'
+        into "amazon-corretto-debugsymbols-${project.version.full}-alpine-linux-${arch_alias}"
     }
-    into "amazon-corretto-debugsymbols-${project.version.full}-alpine-linux-${arch_alias}"
 }
 
 task packageBuildResults(type: Tar) {
@@ -146,7 +146,6 @@ task packageBuildResults(type: Tar) {
     }
     from(jdkResultingImage) {
         include 'bin/**'
-        exclude 'bin/*.diz'
         include 'conf/**'
         include 'include/**'
         include 'jmods/**'
@@ -154,6 +153,7 @@ task packageBuildResults(type: Tar) {
         include 'lib/**'
         include 'man/man1/**'
         include 'release'
+        exclude '**/*.diz'
     }
     into "amazon-corretto-${project.version.full}-alpine-linux-${arch_alias}"
 }

--- a/installers/linux/alpine/tar/build.gradle
+++ b/installers/linux/alpine/tar/build.gradle
@@ -126,7 +126,8 @@ task packageDebugSymbols(type: Tar) {
     archiveName "amazon-corretto-debugsymbols-${project.version.full}-alpine-linux-${arch_alias}.tar.gz"
     compression Compression.GZIP
     from(jdkResultingImage) {
-        include '**/*.diz'
+        include 'bin/*.diz'
+        include 'lib/*.diz'
         into "amazon-corretto-debugsymbols-${project.version.full}-alpine-linux-${arch_alias}"
     }
 }

--- a/installers/linux/universal/tar/build.gradle
+++ b/installers/linux/universal/tar/build.gradle
@@ -116,7 +116,7 @@ task packageDebugSymbols(type: Tar) {
     archiveName "${project.correttoDebugSymbolsArchiveName}.tar.gz"
     compression Compression.GZIP
     from(jdkResultingImage) {
-        include 'bin/*.diz'
+        include '**/*.diz'
         into project.correttoDebugSymbolsArchiveName
     }
 }
@@ -136,13 +136,13 @@ task packageBuildResults(type: Tar) {
     }
     from(jdkResultingImage) {
         include 'bin/**'
-        exclude 'bin/*.diz'
         include 'conf/**'
         include 'include/**'
         include 'jmods/**'
         include 'lib/**'
         include 'man/man1/**'
         include 'release'
+        exclude '**/*.diz'
         into project.correttoJdkArchiveName
     }
 

--- a/installers/linux/universal/tar/build.gradle
+++ b/installers/linux/universal/tar/build.gradle
@@ -116,7 +116,8 @@ task packageDebugSymbols(type: Tar) {
     archiveName "${project.correttoDebugSymbolsArchiveName}.tar.gz"
     compression Compression.GZIP
     from(jdkResultingImage) {
-        include '**/*.diz'
+        include 'bin/*.diz'
+        include 'lib/*.diz'
         into project.correttoDebugSymbolsArchiveName
     }
 }

--- a/installers/mac/tar/build.gradle
+++ b/installers/mac/tar/build.gradle
@@ -161,7 +161,8 @@ task packageDebugSymbols(type: Tar) {
     archiveName "${project.correttoDebugSymbolsArchiveName}.tar.gz"
     compression Compression.GZIP
     from("${jdkResultingImage}/${correttoMacDir}") {
-        include "Contents/Home/**/*.diz"
+        include "Contents/Homebin/bin/*.diz"
+        include "Contents/Homebin/lib/*.diz"
     }
     into "${buildDir}/${correttoMacDir}"
     into project.correttoDebugSymbolsArchiveName

--- a/installers/mac/tar/build.gradle
+++ b/installers/mac/tar/build.gradle
@@ -122,7 +122,6 @@ task prepareArtifacts {
         copy {
             from("${jdkResultingImage}/${correttoMacDir}") {
                 include "Contents/Home/bin/**"
-                exclude "Contents/Home/bin/*.diz"
                 include "Contents/Home/conf/**"
                 include "Contents/Home/include/**"
                 include "Contents/Home/jmods/**"
@@ -132,6 +131,7 @@ task prepareArtifacts {
                 include "Contents/Home/release"
                 include "Contents/Info.plist"
                 include "Contents/MacOS/**"
+                exclude "Contents/Home/**/*.diz"
             }
             into "${buildDir}/${correttoMacDir}"
         }
@@ -161,7 +161,7 @@ task packageDebugSymbols(type: Tar) {
     archiveName "${project.correttoDebugSymbolsArchiveName}.tar.gz"
     compression Compression.GZIP
     from("${jdkResultingImage}/${correttoMacDir}") {
-        include "Contents/Home/bin/*.diz"
+        include "Contents/Home/**/*.diz"
     }
     into "${buildDir}/${correttoMacDir}"
     into project.correttoDebugSymbolsArchiveName

--- a/installers/windows/zip/build.gradle
+++ b/installers/windows/zip/build.gradle
@@ -81,7 +81,8 @@ task packageDebugSymbols(type: Zip) {
     archiveName "${project.correttoDebugSymbolsArchiveName}.zip"
 
     from("${copyImage.destinationDir}/jdk") {
-        include 'bin/*.diz'
+        include '**/*.diz'
+        into project.correttoTestImageArchiveName
     }
 }
 
@@ -91,7 +92,7 @@ task packageBuildResults(type: Zip) {
 
     from("${copyImage.destinationDir}/jdk") {
         exclude 'demo'
-        exclude 'bin/*.diz'
+        exclude '**/*.diz'
     }
     from(buildRoot) {
         include 'ASSEMBLY_EXCEPTION'

--- a/installers/windows/zip/build.gradle
+++ b/installers/windows/zip/build.gradle
@@ -81,8 +81,9 @@ task packageDebugSymbols(type: Zip) {
     archiveName "${project.correttoDebugSymbolsArchiveName}.zip"
 
     from("${copyImage.destinationDir}/jdk") {
-        include '**/*.diz'
-        into project.correttoTestImageArchiveName
+        include 'bin/*.diz'
+        include 'lib/*.diz'
+        into project.correttoDebugSymbolsArchiveName
     }
 }
 


### PR DESCRIPTION
We currently only separates `/bin/*.diz` files into separate tars for release builds. This PR does the same for `/lib/*.diz` files.
