### PR TITLE
Add hostArchitectures to macos pkg files so Rosetta is not required o…

### DIFF
--- a/installers/mac/pkg/build.gradle
+++ b/installers/mac/pkg/build.gradle
@@ -48,7 +48,7 @@ task inflatePkgTemplate {
         copy {
             from('templates/CorrettoPkg.pkgproj.template') {
                 rename { file -> file.replace('.template', '') }
-                filter(org.apache.tools.ant.filters.ReplaceTokens, tokens: ["full": project.version["full"], "major": project.version["major"], "arch": correttoArch])
+                filter(org.apache.tools.ant.filters.ReplaceTokens, tokens: ["full": project.version["full"], "major": project.version["major"], "arch": correttoArch, "macos-arch": (correttoArch == "aarch64" ? "arm64" : "x86_64")])
             }
             into buildRoot
         }

--- a/installers/mac/pkg/templates/CorrettoPkg.pkgproj.template
+++ b/installers/mac/pkg/templates/CorrettoPkg.pkgproj.template
@@ -379,6 +379,13 @@
     </dict>
     <key>PROJECT_SETTINGS</key>
     <dict>
+      <key>ADVANCED_OPTIONS</key>
+      <dict>
+        <key>installer-script.options:hostArchitectures</key>
+        <array>
+          <string>@macos-arch@</string>
+        </array>
+      </dict>
       <key>BUILD_FORMAT</key>
       <integer>0</integer>
       <key>BUILD_PATH</key>


### PR DESCRIPTION
…n m1

`Distributions` in .pkg after change:

```
<?xml version="1.0" encoding="UTF-8"?>
<installer-gui-script authoringTool="Packages" authoringToolVersion="1.2.9" authoringToolBuild="603" minSpecVersion="1.0">
    <options rootVolumeOnly="true" hostArchitectures="x86_64"/>
    <!--+==========================+
        |       Presentation       |
        +==========================+-->
    <title>DISTRIBUTION_TITLE</title>
    <background file="background" scaling="proportional" alignment="bottomleft"/>
    <background-darkAqua file="background" scaling="proportional" alignment="bottomleft"/>
    <welcome file="welcome.html"/>
    <!--+==========================+
        |         Installer        |
        +==========================+-->
    <choices-outline>
        <line choice="installer_choice_1"/>
    </choices-outline>
    <choice id="installer_choice_1" title="amazon-corretto-17.jdk" description="">
        <pkg-ref id="com.amazon.corretto.17"/>
    </choice>
    <!--+==========================+
        |    Package References    |
        +==========================+-->
    <pkg-ref id="com.amazon.corretto.17" version="17.0.0.35.2" auth="Root" installKBytes="313596">#amazon-corretto-17.jdk.pkg</pkg-ref>
</installer-gui-script>```