### PR TITLE
Fix path typo in packaging Mac debug symbols.

### DIFF
--- a/installers/mac/tar/build.gradle
+++ b/installers/mac/tar/build.gradle
@@ -161,8 +161,8 @@ task packageDebugSymbols(type: Tar) {
     archiveName "${project.correttoDebugSymbolsArchiveName}.tar.gz"
     compression Compression.GZIP
     from("${jdkResultingImage}/${correttoMacDir}") {
-        include "Contents/Homebin/bin/*.diz"
-        include "Contents/Homebin/lib/*.diz"
+        include "Contents/Home/bin/*.diz"
+        include "Contents/Home/lib/*.diz"
     }
     into "${buildDir}/${correttoMacDir}"
     into project.correttoDebugSymbolsArchiveName


### PR DESCRIPTION

### Description
Fix path typo in packaging Mac debug symbols.


### How has this been tested?
 Testing build correctly builds a tar with debug symbols.

### Platform information
 Mac

