### PR TITLE
Enable the UseAESCTRIntrinsics by default 

### DIFF
--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
@@ -238,7 +238,7 @@ void VM_Version::initialize() {
       UseAES = true;
     }
     if (FLAG_IS_DEFAULT(UseAESCTRIntrinsics)) {
-      FLAG_SET_DEFAULT(UseAESCTRIntrinsics, false);
+      FLAG_SET_DEFAULT(UseAESCTRIntrinsics, true);
     }
   } else {
     if (UseAES) {


### PR DESCRIPTION
This is a request to enable the UseAESCTRIntrinsics by default since it provides a great performance improvement.

Performance tests were executed on c6g.4xlarge:
```
Fix
Benchmark                                     (dataSize)  (keyLength)  (provider)  Mode  Cnt      Score    Error  Units
o.o.b.j.c.full.AESGCMBench.decrypt                 16384          128              avgt   10  10275.162 ±  5.149  ns/op
o.o.b.j.c.full.AESGCMBench.decryptMultiPart        16384          128              avgt   10  12927.953 ±  8.437  ns/op
o.o.b.j.c.full.AESGCMBench.encrypt                 16384          128              avgt   10  10287.580 ± 20.014  ns/op
o.o.b.j.c.full.AESGCMBench.encryptMultiPart        16384          128              avgt   10  10336.035 ± 14.664  ns/op
o.o.b.j.c.small.AESGCMBench.decrypt                 1024          128              avgt   10   1111.727 ±  0.733  ns/op
o.o.b.j.c.small.AESGCMBench.decryptMultiPart        1024          128              avgt   10   1471.345 ±  1.458  ns/op
o.o.b.j.c.small.AESGCMBench.encrypt                 1024          128              avgt   10   1091.375 ±  0.238  ns/op
o.o.b.j.c.small.AESGCMBench.encryptMultiPart        1024          128              avgt   10   1099.014 ±  0.163  ns/op

Base
Benchmark                                     (dataSize)  (keyLength)  (provider)  Mode  Cnt      Score     Error  Units
o.o.b.j.c.full.AESGCMBench.decrypt                 16384          128              avgt   10  83424.274 ± 340.355  ns/op
o.o.b.j.c.full.AESGCMBench.decryptMultiPart        16384          128              avgt   10  86408.943 ± 149.558  ns/op
o.o.b.j.c.full.AESGCMBench.encrypt                 16384          128              avgt   10  83360.282 ± 352.831  ns/op
o.o.b.j.c.full.AESGCMBench.encryptMultiPart        16384          128              avgt   10  81394.201 ± 483.496  ns/op
o.o.b.j.c.small.AESGCMBench.decrypt                 1024          128              avgt   10   5616.474 ±   6.723  ns/op
o.o.b.j.c.small.AESGCMBench.decryptMultiPart        1024          128              avgt   10   8602.988 ±  42.697  ns/op
o.o.b.j.c.small.AESGCMBench.encrypt                 1024          128              avgt   10   5550.952 ±   9.398  ns/op
o.o.b.j.c.small.AESGCMBench.encryptMultiPart        1024          128              avgt   10   5636.798 ±   4.151  ns/op
```


I have completed the jtreg:tier1, jtreg:tier2, jtreg:tier3, jtreg:tier4 tests no new issues were found.
Jenkins is green.