### PR TITLE
Add dependency on log4j-cve-2021-44228-static-mitigation

### DIFF
--- a/installers/linux/al2/spec/java-amazon-corretto.spec.template
+++ b/installers/linux/al2/spec/java-amazon-corretto.spec.template
@@ -148,6 +148,7 @@ Requires: zlib
 Requires: fontconfig
 Requires: freetype
 Requires: ca-certificates
+Requires: log4j-cve-2021-44228-cve-mitigations
 Requires(post): chkconfig
 Requires(postun): chkconfig
 
@@ -396,6 +397,8 @@ fi
 %license %{java_imgdir}/docs/legal
 
 %changelog
+* Tue Dec 16 2021 Clive Verghese <verghese@amazon.com> 
+- Add requires for log4j CVE-2021-44228 static mitigation
 * Fri Oct 29 2021 Dan Lutker <lutkerd@amazon.com>
 - Update packaging model to include devel and jmods
 - Fixes for alternatives priority


### PR DESCRIPTION
### Description
Add dependency on `log4j-cve-2021-44228-cve-mitigations` for AL2 packages.

Backport of : https://github.com/corretto/corretto-jdk/commit/ebeacc075dcd06d2de63a36d65cd5a57c907d748


