### PR TITLE
Fix missing libLingeredApp.so failing jtregs

### DIFF
--- a/installers/linux/alpine/tar/build.gradle
+++ b/installers/linux/alpine/tar/build.gradle
@@ -106,7 +106,7 @@ task executeBuild(type: Exec) {
 task createTestImage(type: Exec) {
     dependsOn executeBuild
     workingDir "$buildRoot"
-    commandLine 'make','test-image-hotspot-jtreg-native','test-image-jdk-jtreg-native'
+    commandLine 'make','test-image'
 }
 
 task packageTestImage(type: Tar) {

--- a/installers/linux/universal/tar/build.gradle
+++ b/installers/linux/universal/tar/build.gradle
@@ -96,7 +96,7 @@ task executeBuild(type: Exec) {
 task createTestImage(type: Exec) {
     dependsOn executeBuild
     workingDir "$buildRoot"
-    commandLine 'make','test-image-hotspot-jtreg-native','test-image-jdk-jtreg-native'
+    commandLine 'make','test-image'
 }
 
 task packageTestImage(type: Tar) {

--- a/installers/mac/tar/build.gradle
+++ b/installers/mac/tar/build.gradle
@@ -83,7 +83,7 @@ task executeBuild(type: Exec) {
 task executeTestBuild(type: Exec) {
     dependsOn executeBuild
     workingDir "$buildRoot"
-    commandLine 'make','test-image-hotspot-jtreg-native','test-image-jdk-jtreg-native'
+    commandLine 'make','test-image'
 }
 
 task prepareArtifacts {

--- a/installers/windows/zip/build.gradle
+++ b/installers/windows/zip/build.gradle
@@ -57,7 +57,7 @@ task executeBuild(type: Exec) {
     dependsOn configureBuild
     workingDir buildRoot
 
-    commandLine 'make', 'clean', 'images', 'test-image-hotspot-jtreg-native', 'test-image-jdk-jtreg-native'
+    commandLine 'make', 'clean', 'images', 'test-image'
 }
 
 task copyImage(type: Copy) {


### PR DESCRIPTION
### Description

I'm seeing jtreg tier 1 failures when using these installers on various platforms, with error message:

```
Execution failed: main' threw exception: java.lang.RuntimeException:
Test ERROR java.lang.RuntimeException: Output doesn't contain the
location of core file.: expected true, was false
```

In tests:

```
serviceability/sa/ClhsdbFindPC.java$id1
serviceability/sa/ClhsdbFindPC.java$id3
serviceability/sa/ClhsdbPmap.java$id1
serviceability/sa/ClhsdbPstack.java$id1
```

The error is not very helpful, but basically any time the LingeredApp which
is used for testing crashes unexpectedly, we will see this error
because stdout is empty. The actual problem is hidden in LingeredApp's
stderr, which I enabled manually, and it shows that the native
library is missing:

```
 LingeredApp stderr: [Exception in thread "main" java.lang.UnsatisfiedLinkError: no LingeredApp in java.library.path: /usr/java/packages/lib:/usr/lib64:/lib64:/lib:/usr/lib
	at java.base/java.lang.ClassLoader.loadLibrary(ClassLoader.java:2429)
	at java.base/java.lang.Runtime.loadLibrary0(Runtime.java:818)
	at java.base/java.lang.System.loadLibrary(System.java:1989)
	at jdk.test.lib.apps.LingeredApp.main(LingeredApp.java:593)
]
```

Running `make test-image-hotspot-jtreg-native test-image-jdk-jtreg-native`
doesn't build `libLingeredApp.so`, but running `make test-image` does, because
it includes `test-image-lib-native`, so switching to that.

```
# *after* running make test-image-hotspot-jtreg-native test-image-jdk-jtreg-native
make test-image-lib-native
Building target 'test-image-lib-native' in configuration 'linux-x86_64-server-release'
Creating support/test/lib/native/lib/libLingeredApp.so from 1 file(s)
Creating support/test/lib/native/lib/libFileUtils.so from 1 file(s)
```

I'm not sure why this hasn't shown up before, so it's possible my fix doesn't make sense.

### Related issues


### Motivation and context


### How has this been tested?

I re-ran the build, and no longer saw the same error. 3 platforms were completely fixed (jtreg1 passed), 2 (I think) platforms still had some errors but they looked unrelated.