### PR TITLE
Set BUILD_NUMBER

### DIFF
--- a/.github/actions/update-version/update-version.sh
+++ b/.github/actions/update-version/update-version.sh
@@ -18,7 +18,7 @@ BUILD_NUMBER=$(git ls-remote --tags ${UPSTREAM_REMOTE} |grep jdk-${DEFAULT_VERSI
 # Load the current Corretto version
 CURRENT_VERSION=$(cat version.txt)
 
-if [[ ${CURRENT_VERSION} == ${DEFAULT_VERSION_FEATURE}.${DEFAULT_VERSION_INTERIM}.${DEFAULT_VERSION_UPDATE}.${BUILD_NUMBER}.* ]]; then
+if [[ ${CURRENT_VERSION} == ${DEFAULT_VERSION_FEATURE}.${DEFAULT_VERSION_INTERIM}.${DEFAULT_VERSION_UPDATE}.${BUILD_NUMBER:=0}.* ]]; then
     echo "Corretto version is current."
 else
     echo "Updating Corretto version"


### PR DESCRIPTION
When there is not tag for the build it would inset "" for the build number. 
Setting a default value of 0 so that it still parses correctly.

