### PR TITLE
AL2022: Require javapackages-filesystem over jpackage-utils

### DIFF
--- a/installers/linux/al2/spec/java-amazon-corretto.spec.template
+++ b/installers/linux/al2/spec/java-amazon-corretto.spec.template
@@ -79,10 +79,11 @@ Vendor: Amazon
 Url: https://github.com/corretto/corretto-${java_spec_version}
 Source0: amazon-corretto-source-%{java_version}.%{build_id}.%{release_id}.tar.gz
 
-# jpackage-utils is required for both build and runtime.
-# For build, it provides the jvmdir macro. For runtime,
-# it provides the /usr/lib/jvm directory.
+%if "%{dist}" == ".amzn2"
 BuildRequires: jpackage-utils
+%else
+BuildRequires: javapackages-filesystem
+%endif
 BuildRequires: autoconf
 BuildRequires: make
 BuildRequires: alsa-lib-devel
@@ -143,7 +144,11 @@ Summary: Amazon Corretto headless development environment
 Group:   Development/Tools
 AutoReqProv: no
 
+%if "%{dist}" == ".amzn2"
 Requires: jpackage-utils
+%else
+Requires: javapackages-filesystem
+%endif
 Requires: zlib
 Requires: fontconfig
 Requires: freetype


### PR DESCRIPTION
jpackage-utils requires openjdk11

