### PR TITLE
AL2022: Remove GIFLIB define

### DIFF
--- a/installers/linux/al2/spec/java-amazon-corretto.spec.template
+++ b/installers/linux/al2/spec/java-amazon-corretto.spec.template
@@ -211,14 +211,21 @@ Amazon Corretto's packaging of the OpenJDK ${java_spec_version} jmods.
 %setup -q -n src -c
 
 %build
+
+%if "%{dist}" == ".amzn2" || "%{dist}" == ".amzn2int"
 # AmazonLinux ships with GifLib 4.x which does not define GIFLIB_MAJOR. This must be defined
 # because -Werror=undef is enabled.
+%define GIFLIB_DEFINE "-DGIFLIB_MAJOR=4"
+%endif
+
 bash ./configure \\
 %ifarch aarch64
-        --with-extra-cflags="-moutline-atomics -DGIFLIB_MAJOR=4" \\
+        --with-extra-cflags="-moutline-atomics %{GIFLIB_DEFINE}" \\
         --with-extra-cxxflags="-moutline-atomics" \\
 %else
-        --with-extra-cflags="-DGIFLIB_MAJOR=4" \\
+%if "%{?GIFLIB_DEFINE:1}" == "1"
+        --with-extra-cflags="%{GIFLIB_DEFINE}" \\
+%endif
 %endif
         --with-jvm-features="zgc shenandoahgc" \\
         --with-version-feature="${java_spec_version}" \\


### PR DESCRIPTION
This was required on AL2 but not on AL2022 which
has 5.x.

### How has this been tested?

Built on both AL2 and AL2022 on x86_64 and saw the correct configure flags passed on each.

