### PR TITLE
AL: Fix to only add GIFLIB when defined

### DIFF
--- a/installers/linux/al2/spec/java-amazon-corretto.spec.template
+++ b/installers/linux/al2/spec/java-amazon-corretto.spec.template
@@ -220,7 +220,7 @@ Amazon Corretto's packaging of the OpenJDK ${java_spec_version} jmods.
 
 bash ./configure \\
 %ifarch aarch64
-        --with-extra-cflags="-moutline-atomics %{GIFLIB_DEFINE}" \\
+        --with-extra-cflags="-moutline-atomics%{?GIFLIB_DEFINE: %{GIFLIB_DEFINE}}" \\
         --with-extra-cxxflags="-moutline-atomics" \\
 %else
 %if "%{?GIFLIB_DEFINE:1}" == "1"


### PR DESCRIPTION
### How has this been tested?
Built on AL2 and AL2022 both x64 and aarch64.