### PR TITLE
Update macos packaging logic to avoid duplicate paths after installation

### DIFF
--- a/installers/mac/pkg/build.gradle
+++ b/installers/mac/pkg/build.gradle
@@ -69,12 +69,12 @@ task setupDirectories {
     doLast {
         exec {
             workingDir buildRoot
-            commandLine "mkdir", "-p", "pkgroot/Library/Java/JavaVirtualMachines"
+            commandLine "mkdir", "-p", "pkgroot/"
         }
 
         exec {
             workingDir buildRoot
-            commandLine "cp", "-Rf", "amazon-corretto-${project.version.major}.jdk", "pkgroot/Library/Java/JavaVirtualMachines/"
+            commandLine "cp", "-Rf", "amazon-corretto-${project.version.major}.jdk", "pkgroot/"
         }
 
         exec {
@@ -100,7 +100,7 @@ task generateInstaller {
                 "--version", project.version.full,
                 "--ownership", "recommended",
                 "--scripts", "resources",
-                "--install-location", "/Library/Java/JavaVirtualMachines/amazon-corretto-${project.version.major}.jdk",
+                "--install-location", "/Library/Java/JavaVirtualMachines/",
                 "build/components/amazon-corretto-${project.version.major}.jdk.pkg"
         }
 


### PR DESCRIPTION
Clean backport from tip