### PR TITLE
AL: Add provides java-devel

### DIFF
--- a/installers/linux/al2/spec/java-amazon-corretto.spec.template
+++ b/installers/linux/al2/spec/java-amazon-corretto.spec.template
@@ -188,6 +188,7 @@ Summary: Amazon Corretto ${java_spec_version} development tools
 Group: Development
 AutoReqProv: no
 
+Provides: java-devel = %{epoch}:%{java_version}
 Provides: java-${java_spec_version}-devel = %{epoch}:%{java_version}
 Provides: java-${java_spec_version}-devel = %{epoch}:%{version}-%{release}
 Requires: %{name}-headless%{?1}%{?_isa} = %{epoch}:%{version}-%{release}
@@ -446,6 +447,9 @@ fi
 %license %{java_imgdir}/docs/legal
 
 %changelog
+* Fri Jul 22 2022 Dan Lutker <lutkerd@amazon.com>
+- Add provides java-devel
+
 * Thu Jun 30 2022 Dan Lutker <lutkerd@amazon.com>
 - Fixup java/jre symlinks
 


### PR DESCRIPTION
Backporting from CorrettoJdk

### How has this been tested?
Built AL2022  and AL2 rpms locally and verified the provides