### PR TITLE
Fix java_home alternative

### DIFF
--- a/installers/linux/al2/spec/java-amazon-corretto.spec.template
+++ b/installers/linux/al2/spec/java-amazon-corretto.spec.template
@@ -265,6 +265,7 @@ popd
 %post headless
 if [ \$1 -eq 1 ] ; then
   alternatives --install %{_bindir}/java java %{java_home}/bin/java %{alternatives_priority} \\
+               --slave %{_jvmdir}/%{name} %{name} %{java_home} \\
                --slave %{_jvmdir}/jre jre %{java_home} \\
                --slave %{_jvmdir}/jre-openjdk jre_openjdk %{java_home} \\
                --slave %{_bindir}/keytool keytool %{java_home}/bin/keytool \\
@@ -281,7 +282,6 @@ fi
 %post devel
 if [ \$1 -eq 1 ] ; then
   alternatives --install %{_bindir}/javac javac %{java_home}/bin/javac %{alternatives_priority} \\
-               --slave %{_jvmdir}/%{name} %{name} %{java_home} \\
                --slave %{_jvmdir}/java java_sdk %{java_home} \\
                --slave %{_bindir}/jar jar %{java_home}/bin/jar \\
                --slave %{_bindir}/jarsigner jarsigner %{java_home}/bin/jarsigner \\


### PR DESCRIPTION
Fix for https://github.com/corretto/corretto-docker/issues/129

Built and tested locally with the headless package and the path is created as expected.

```
bash-4.2# ls -l /usr/lib/jvm
total 4
lrwxrwxrwx 1 root root   41 Dec 28 19:51 java-17-amazon-corretto -> /etc/alternatives/java-17-amazon-corretto
drwxr-xr-x 7 root root 4096 Dec 28 19:51 java-17-amazon-corretto.x86_64
lrwxrwxrwx 1 root root   21 Dec 28 19:51 jre -> /etc/alternatives/jre
lrwxrwxrwx 1 root root   24 Dec 28 19:51 jre-17 -> /etc/alternatives/jre_17
lrwxrwxrwx 1 root root   32 Dec 28 19:51 jre-17-openjdk -> /etc/alternatives/jre_17_openjdk
lrwxrwxrwx 1 root root   29 Dec 28 19:51 jre-openjdk -> /etc/alternatives/jre_openjdk
bash-4.2# realpath /usr/lib/jvm/java-17-amazon-corretto
/usr/lib/jvm/java-17-amazon-corretto.x86_64
```