### PR TITLE
Fix provides for public shared libs

### DIFF
--- a/installers/linux/al2/spec/java-amazon-corretto.spec.template
+++ b/installers/linux/al2/spec/java-amazon-corretto.spec.template
@@ -55,9 +55,19 @@
 %global abs2rel %{__perl} -e %{script}
 
 # Filter out private libraries so RPM does not list them as provided/required
-%global _privatelibs libjli[.]so.*
+%global _privatelibs libjli[.]so.*|libattach[.]so.*|libawt_headless[.]so.*|libawt[.]so.*|libdt_socket[.]so.*|libextnet[.]so.*|libfontmanager[.]so.*|libinstrument[.]so.*|libj2gss[.]so.*|libj2pcsc[.]so.*|libj2pkcs11[.]so.*|libjaas[.]so.*|libjavajpeg[.]so.*|libjdwp[.]so.*|libjimage[.]so.*|libjsound[.]so.*|libjsvml[.]so.*|liblcms[.]so.*|libmanagement[.]so.*|libmanagement_agent[.]so.*|libmanagement_ext[.]so.*|libmlib_image[.]so.*|libnet[.]so.*|libnio[.]so.*|libprefs[.]so.*|librmi[.]so.*|libsaproc[.]so.*|libsctp[.]so.*|libsyslookup[.]so.*|libzip[.]so.*|libsplashscreen[.]so.*|libawt_xawt[.]so.*
+%global _publiclibs libjawt[.]so.*|libjava.so.*|libjsig.so.*|libjvm.so.*|libverify.so.*
+
+%if "%{dist}" == ".amzn2" || "%{dist}" == ".amzn2int"
+# On AL2 we don't want to list any libraries as Provides to keep existing functionality
+%global __provides_exclude ^(%{_privatelibs}|%{_publiclibs})\$
+%global __requires_exclude ^(%{_privatelibs}|%{_publiclibs})\$
+%else
+# On newer AL versions, we will want only the latest LTS at release time to provide the public libs.
+# Having multiple versions of Java providing the libs will cause problems. (https://bugzilla.redhat.com/show_bug.cgi?id=1702356)
 %global __provides_exclude ^(%{_privatelibs})\$
 %global __requires_exclude ^(%{_privatelibs})\$
+%endif
 
 # By default install a bootstrap jdk. If one is already available,
 # this can be skipped using --without bootjdk
@@ -73,7 +83,8 @@ Release: %{release_id}%{?dist}%{?release_ext:.%{release_ext}}
 
 Epoch: 1
 Group: Development/Languages
-AutoReqProv: no
+AutoProv: 1
+AutoReq: 0
 License: ASL 1.1 and ASL 2.0 and BSD and BSD with advertising and GPL+ and GPLv2 and GPLv2 with exceptions and IJG and LGPLv2+ and MIT and MPLv2.0 and Public Domain and W3C and zlib and ISC and FTL and RSA.
 Vendor: Amazon
 Url: https://github.com/corretto/corretto-${java_spec_version}
@@ -140,7 +151,8 @@ OpenJDK ${java_spec_version} code.
 %package headless
 Summary: Amazon Corretto headless development environment
 Group:   Development/Tools
-AutoReqProv: no
+AutoProv: 1
+AutoReq: 0
 
 %if "%{dist}" == ".amzn2" || "%{dist}" == ".amzn2int"
 Requires: jpackage-utils
@@ -186,7 +198,8 @@ Amazon Corretto's packaging of the OpenJDK ${java_spec_version} API documentatio
 %package devel
 Summary: Amazon Corretto ${java_spec_version} development tools
 Group: Development
-AutoReqProv: no
+AutoProv: 1
+AutoReq: 0
 
 Provides: java-devel = %{epoch}:%{java_version}
 Provides: java-${java_spec_version}-devel = %{epoch}:%{java_version}
@@ -254,6 +267,12 @@ rm -rf %{buildroot}
 install -d -m 755 %{buildroot}%{java_home}
 cp -a %{java_imgdir}/jdk/* %{buildroot}%{java_home}
 rm -rf %{buildroot}%{java_home}/demo
+
+# Properly set permissions for executables and libs to enable auto-provides scanning
+find %{buildroot}%{java_home}/ -name "*.so" -exec chmod 755 \\{\\} \\; ;
+find %{buildroot}%{java_home} -type d -exec chmod 755 \\{\\} \\; ;
+# Set legal to read-only.
+find %{buildroot}%{java_home}/legal -type f -exec chmod 644 \\{\\} \\; ;
 
 # Make a *relative* symlink pointing to the cacerts file from ca-certificates.
 rm -f %{buildroot}%{java_home}/lib/security/cacerts
@@ -447,6 +466,9 @@ fi
 %license %{java_imgdir}/docs/legal
 
 %changelog
+* Mon Oct 10 2022 Dan Lutker <lutkerd@amazon.com>
+- Fix provides to include public shared libs
+
 * Mon Aug 29 2022 Dan Lutker <lutkerd@amazon.com>
 - Move requires for jpeg, alsa and fonts to headless package
 


### PR DESCRIPTION
This is an update of https://github.com/corretto/corretto-17/pull/98 which cannot be reopened. The updated change only makes the public java libs "Provided" for newer versions of AmazonLinux and not for AL2 as that may cause some issues with the system provided JDK.

Built the changes locally for AL2 and AL2022 and checked the provides for the headless and all other RPMs.

```
Current AL2

$ repoquery java-17-amazon-corretto-headless --provides
java-17-amazon-corretto-headless = 1:17.0.5+8-1.amzn2.1
java-17-amazon-corretto-headless(x86-64) = 1:17.0.5+8-1.amzn2.1
java-17-headless = 1:17.0.5+8-1.amzn2.1
java-headless = 1:17.0.5
jre-17-amazon-corretto-headless = 1:17.0.5+8-1.amzn2.1
jre-17-headless = 1:17.0.5+8-1.amzn2.1
jre-headless = 1:17.0.5

$ repoquery java-17-amazon-corretto --provides
java = 1:17.0.5
java-17 = 1:17.0.5
java-17 = 1:17.0.5+8-1.amzn2.1
java-17-amazon-corretto = 1:17.0.5+8-1.amzn2.1
java-17-amazon-corretto(x86-64) = 1:17.0.5+8-1.amzn2.1
jre = 17.0.5
jre-17 = 1:17.0.5+8-1.amzn2.1
jre-17-amazon-corretto = 1:17.0.5+8-1.amzn2.1

$ repoquery java-17-amazon-corretto-devel --provides
java-17-amazon-corretto-devel = 1:17.0.5+8-1.amzn2.1
java-17-amazon-corretto-devel(x86-64) = 1:17.0.5+8-1.amzn2.1
java-17-devel = 1:17.0.5
java-17-devel = 1:17.0.5+8-1.amzn2.1
java-devel = 1:17.0.5


Updated AL2
$ rpm -qp ~/rpmbuild/RPMS/x86_64/java-17-amazon-corretto-headless-17.0.6+9-1.amzn2int.1.x86_64.rpm --provides
config(java-17-amazon-corretto-headless) = 1:17.0.6+9-1.amzn2int.1
java-17-amazon-corretto-headless = 1:17.0.6+9-1.amzn2int.1
java-17-amazon-corretto-headless(x86-64) = 1:17.0.6+9-1.amzn2int.1
java-17-headless = 1:17.0.6+9-1.amzn2int.1
java-headless = 1:17.0.6
jre-17-amazon-corretto-headless = 1:17.0.6+9-1.amzn2int.1
jre-17-headless = 1:17.0.6+9-1.amzn2int.1
jre-headless = 1:17.0.6

$ rpm -qp ~/rpmbuild/RPMS/x86_64/java-17-amazon-corretto-17.0.6+9-1.amzn2int.1.x86_64.rpm --provides
java = 1:17.0.6
java-17 = 1:17.0.6
java-17 = 1:17.0.6+9-1.amzn2int.1
java-17-amazon-corretto = 1:17.0.6+9-1.amzn2int.1
java-17-amazon-corretto(x86-64) = 1:17.0.6+9-1.amzn2int.1
jre = 17.0.6
jre-17 = 1:17.0.6+9-1.amzn2int.1
jre-17-amazon-corretto = 1:17.0.6+9-1.amzn2int.1

$ rpm -qp ~/rpmbuild/RPMS/x86_64/java-17-amazon-corretto-devel-17.0.6+9-1.amzn2int.1.x86_64.rpm --provides
java-17-amazon-corretto-devel = 1:17.0.6+9-1.amzn2int.1
java-17-amazon-corretto-devel(x86-64) = 1:17.0.6+9-1.amzn2int.1
java-17-devel = 1:17.0.6
java-17-devel = 1:17.0.6+9-1.amzn2int.1
java-devel = 1:17.0.6


Upodated AL2022
# rpm -qp /root/rpmbuild/RPMS/x86_64/java-17-amazon-corretto-headless-17.0.6+9-1.amzn2022.1.x86_64.rpm --provides
config(java-17-amazon-corretto-headless) = 1:17.0.6+9-1.amzn2022.1
java-17-amazon-corretto-headless = 1:17.0.6+9-1.amzn2022.1
java-17-amazon-corretto-headless(x86-64) = 1:17.0.6+9-1.amzn2022.1
java-17-headless = 1:17.0.6+9-1.amzn2022.1
java-headless = 1:17.0.6
jre-17-amazon-corretto-headless = 1:17.0.6+9-1.amzn2022.1
jre-17-headless = 1:17.0.6+9-1.amzn2022.1
jre-headless = 1:17.0.6
libjava.so()(64bit)
libjsig.so()(64bit)
libjvm.so()(64bit)
libjvm.so(SUNWprivate_1.1)(64bit)
libverify.so()(64bit)

# rpm -qp /root/rpmbuild/RPMS/x86_64/java-17-amazon-corretto-17.0.6+9-1.amzn2022.1.x86_64.rpm --provides
java = 1:17.0.6
java-17 = 1:17.0.6
java-17 = 1:17.0.6+9-1.amzn2022.1
java-17-amazon-corretto = 1:17.0.6+9-1.amzn2022.1
java-17-amazon-corretto(x86-64) = 1:17.0.6+9-1.amzn2022.1
jre = 17.0.6
jre-17 = 1:17.0.6+9-1.amzn2022.1
jre-17-amazon-corretto = 1:17.0.6+9-1.amzn2022.1
libjawt.so()(64bit)

# rpm -qp /root/rpmbuild/RPMS/x86_64/java-17-amazon-corretto-devel-17.0.6+9-1.amzn2022.1.x86_64.rpm --provides
java-17-amazon-corretto-devel = 1:17.0.6+9-1.amzn2022.1
java-17-amazon-corretto-devel(x86-64) = 1:17.0.6+9-1.amzn2022.1
java-17-devel = 1:17.0.6
java-17-devel = 1:17.0.6+9-1.amzn2022.1
java-devel = 1:17.0.6

```

