### PR TITLE
8299544: Improve performance of CRC32C intrinsics (non-AVX-512) for s…

### DIFF
--- a/src/hotspot/cpu/x86/crc32c.h
+++ b/src/hotspot/cpu/x86/crc32c.h
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+* Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
 * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 *
 * This code is free software; you can redistribute it and/or modify it
@@ -39,15 +39,15 @@ enum {
   // based on ubench study using methodology described in
   // V. Gopal et al. / Fast CRC Computation for iSCSI Polynomial Using CRC32 Instruction April 2011 8
   //
-  // arbitrary value between 27 and 256
-  CRC32C_MIDDLE = 8 * 86,
+  // arbitrary value between 9 and 256
+  CRC32C_MIDDLE = 8 * 74,
 
   // V. Gopal et al. / Fast CRC Computation for iSCSI Polynomial Using CRC32 Instruction April 2011 9
-  // shows that 240 and 1024 are equally good choices as the 216==8*27
+  // shows that 240 and 1024 are equally good choices as the 216==8*9*3
   //
   // Selecting the smallest value which resulted in a significant performance improvement over
   // sequential version
-  CRC32C_LOW = 8 * 27,
+  CRC32C_LOW = 8 * 9,
 
   CRC32C_NUM_ChunkSizeInBytes = 3,
 

--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -7937,24 +7937,27 @@ void MacroAssembler::crc32c_ipl_alg2_alt2(Register in_out, Register in1, Registe
   addl(tmp1, in2);
   addq(tmp1, in1);
 
-  BIND(L_wordByWord);
   cmpq(in1, tmp1);
-  jcc(Assembler::greaterEqual, L_byteByByteProlog);
-    crc32(in_out, Address(in1, 0), 4);
-    addq(in1, 4);
-    jmp(L_wordByWord);
+  jccb(Assembler::greaterEqual, L_byteByByteProlog);
+  align(16);
+  BIND(L_wordByWord);
+    crc32(in_out, Address(in1, 0), 8);
+    addq(in1, 8);
+    cmpq(in1, tmp1);
+    jcc(Assembler::less, L_wordByWord);
 
   BIND(L_byteByByteProlog);
   andl(in2, 0x00000007);
   movl(tmp2, 1);
 
-  BIND(L_byteByByte);
   cmpl(tmp2, in2);
   jccb(Assembler::greater, L_exit);
+  BIND(L_byteByByte);
     crc32(in_out, Address(in1, 0), 1);
     incq(in1);
     incl(tmp2);
-    jmp(L_byteByByte);
+    cmpl(tmp2, in2);
+    jcc(Assembler::lessEqual, L_byteByByte);
 
   BIND(L_exit);
 }


### PR DESCRIPTION
### Description

Backport of [JDK-8299544](https://bugs.openjdk.org/browse/JDK-8299544)

### Related issues


### Motivation and context


### How has this been tested?

The following tests passed.
```
test/jdk/java/util/zip/TestCRC32C.java
test/hotspot/jtreg/compiler/intrinsics/zip/TestCRC32C.java
```

### Platform information

x86_64

### Additional context
