### PR TITLE
8300584: Accelerate AVX-512 CRC32C for small buffers

### DIFF
--- a/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
@@ -6494,33 +6494,45 @@ address generate_avx_ghash_processBlocks() {
 
       BLOCK_COMMENT("Entry:");
       __ enter(); // required for proper stackwalking of RuntimeStub frame
+      Label L_continue;
+
       if (VM_Version::supports_sse4_1() && VM_Version::supports_avx512_vpclmulqdq() &&
           VM_Version::supports_avx512bw() &&
           VM_Version::supports_avx512vl()) {
+        Label L_doSmall;
+
+        __ cmpl(len, 384);
+        __ jcc(Assembler::lessEqual, L_doSmall);
+
         __ lea(j, ExternalAddress(StubRoutines::x86::crc32c_table_avx512_addr()));
         __ kernel_crc32_avx512(crc, buf, len, j, l, k);
-      } else {
-#ifdef _WIN64
-        __ push(y);
-        __ push(z);
-#endif
-        __ crc32c_ipl_alg2_alt2(crc, buf, len,
-                                a, j, k,
-                                l, y, z,
-                                c_farg0, c_farg1, c_farg2,
-                                is_pclmulqdq_supported);
-#ifdef _WIN64
-        __ pop(z);
-        __ pop(y);
-#endif
+
+        __ jmp(L_continue);
+
+        __ bind(L_doSmall);
       }
+#ifdef _WIN64
+      __ push(y);
+      __ push(z);
+#endif
+      __ crc32c_ipl_alg2_alt2(crc, buf, len,
+                              a, j, k,
+                              l, y, z,
+                              c_farg0, c_farg1, c_farg2,
+                              is_pclmulqdq_supported);
+#ifdef _WIN64
+      __ pop(z);
+      __ pop(y);
+#endif
+
+      __ bind(L_continue);
       __ movl(rax, crc);
       __ vzeroupper();
       __ leave(); // required for proper stackwalking of RuntimeStub frame
       __ ret(0);
 
       return start;
-  }
+}
 
 
   /***


### PR DESCRIPTION
### Description

Backport of [JDK-8300584](https://bugs.openjdk.org/browse/JDK-8300584)

### Related issues


### Motivation and context


### How has this been tested?

The following tests have passed.
```
test/jdk/java/util/zip/TestCRC32C.java
test/hotspot/jtreg/compiler/intrinsics/zip/TestCRC32C.java
```

### Platform information

x86_64


### Additional context
