### PR TITLE
8302113: Improve CRC32 intrinsic with crypto pmull on AArch64

### DIFF
--- a/src/hotspot/cpu/aarch64/globals_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/globals_aarch64.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2015, 2019, Red Hat Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -87,6 +87,8 @@ define_pd_global(intx, InlineSmallCode,          1000);
           "Use Neon for CRC32 computation")                             \
   product(bool, UseCRC32, false,                                        \
           "Use CRC32 instructions for CRC32 computation")               \
+  product(bool, UseCryptoPmullForCRC32, false,                          \
+          "Use Crypto PMULL instructions for CRC32 computation")        \
   product(bool, UseSIMDForMemoryOps, false,                             \
           "Use SIMD instructions in generated memory move code")        \
   product(bool, UseSIMDForArrayEquals, true,                            \

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -3343,6 +3343,65 @@ void MacroAssembler::update_word_crc32(Register crc, Register v, Register tmp,
   eor(crc, crc, tmp);
 }
 
+void MacroAssembler::kernel_crc32_using_crypto_pmull(Register crc, Register buf,
+        Register len, Register tmp0, Register tmp1, Register tmp2, Register tmp3) {
+    Label CRC_by4_loop, CRC_by1_loop, CRC_less128, CRC_by128_pre, CRC_by32_loop, CRC_less32, L_exit;
+    assert_different_registers(crc, buf, len, tmp0, tmp1, tmp2);
+
+    subs(tmp0, len, 384);
+    mvnw(crc, crc);
+    br(Assembler::GE, CRC_by128_pre);
+  BIND(CRC_less128);
+    subs(len, len, 32);
+    br(Assembler::GE, CRC_by32_loop);
+  BIND(CRC_less32);
+    adds(len, len, 32 - 4);
+    br(Assembler::GE, CRC_by4_loop);
+    adds(len, len, 4);
+    br(Assembler::GT, CRC_by1_loop);
+    b(L_exit);
+
+  BIND(CRC_by32_loop);
+    ldp(tmp0, tmp1, Address(buf));
+    crc32x(crc, crc, tmp0);
+    ldp(tmp2, tmp3, Address(buf, 16));
+    crc32x(crc, crc, tmp1);
+    add(buf, buf, 32);
+    crc32x(crc, crc, tmp2);
+    subs(len, len, 32);
+    crc32x(crc, crc, tmp3);
+    br(Assembler::GE, CRC_by32_loop);
+    cmn(len, (u1)32);
+    br(Assembler::NE, CRC_less32);
+    b(L_exit);
+
+  BIND(CRC_by4_loop);
+    ldrw(tmp0, Address(post(buf, 4)));
+    subs(len, len, 4);
+    crc32w(crc, crc, tmp0);
+    br(Assembler::GE, CRC_by4_loop);
+    adds(len, len, 4);
+    br(Assembler::LE, L_exit);
+  BIND(CRC_by1_loop);
+    ldrb(tmp0, Address(post(buf, 1)));
+    subs(len, len, 1);
+    crc32b(crc, crc, tmp0);
+    br(Assembler::GT, CRC_by1_loop);
+    b(L_exit);
+
+  BIND(CRC_by128_pre);
+    kernel_crc32_common_fold_using_crypto_pmull(crc, buf, len, tmp0, tmp1, tmp2,
+      4*256*sizeof(juint) + 8*sizeof(juint));
+    mov(crc, 0);
+    crc32x(crc, crc, tmp0);
+    crc32x(crc, crc, tmp1);
+
+    cbnz(len, CRC_less128);
+
+  BIND(L_exit);
+    mvnw(crc, crc);
+}
+
 void MacroAssembler::kernel_crc32_using_crc32(Register crc, Register buf,
         Register len, Register tmp0, Register tmp1, Register tmp2,
         Register tmp3) {
@@ -3454,6 +3513,11 @@ void MacroAssembler::kernel_crc32(Register crc, Register buf, Register len,
         Register tmp, Register tmp2, Register tmp3) {
   Label L_by16, L_by16_loop, L_by4, L_by4_loop, L_by1, L_by1_loop, L_exit;
   uint64_t offset;
+
+  if (UseCryptoPmullForCRC32) {
+      kernel_crc32_using_crypto_pmull(crc, buf, len, table0, table1, table2, table3);
+      return;
+  }
 
   if (UseCRC32) {
       kernel_crc32_using_crc32(crc, buf, len, table0, table1, table2, table3);
@@ -3751,6 +3815,123 @@ void MacroAssembler::kernel_crc32c(Register crc, Register buf, Register len,
   kernel_crc32c_using_crc32c(crc, buf, len, table0, table1, table2, table3);
 }
 
+void MacroAssembler::kernel_crc32_common_fold_using_crypto_pmull(Register crc, Register buf,
+        Register len, Register tmp0, Register tmp1, Register tmp2, size_t table_offset) {
+    Label CRC_by128_loop;
+    assert_different_registers(crc, buf, len, tmp0, tmp1, tmp2);
+
+    sub(len, len, 256);
+    Register table = tmp0;
+    {
+      uint64_t offset;
+      adrp(table, ExternalAddress(StubRoutines::crc_table_addr()), offset);
+      add(table, table, offset);
+    }
+    add(table, table, table_offset);
+
+    sub(buf, buf, 0x10);
+    ldrq(v1, Address(buf, 0x10));
+    ldrq(v2, Address(buf, 0x20));
+    ldrq(v3, Address(buf, 0x30));
+    ldrq(v4, Address(buf, 0x40));
+    ldrq(v5, Address(buf, 0x50));
+    ldrq(v6, Address(buf, 0x60));
+    ldrq(v7, Address(buf, 0x70));
+    ldrq(v8, Address(pre(buf, 0x80)));
+
+    movi(v25, T4S, 0);
+    mov(v25, T4S, 0, crc);
+    eor(v1, T16B, v1, v25);
+
+    ldrq(v0, Address(table));
+    b(CRC_by128_loop);
+
+    align(OptoLoopAlignment);
+  BIND(CRC_by128_loop);
+    pmull (v9,  T1Q, v1, v0, T1D);
+    pmull2(v10, T1Q, v1, v0, T2D);
+    ldrq(v1, Address(buf, 0x10));
+    eor3(v1, T16B, v9,  v10, v1);
+
+    pmull (v11, T1Q, v2, v0, T1D);
+    pmull2(v12, T1Q, v2, v0, T2D);
+    ldrq(v2, Address(buf, 0x20));
+    eor3(v2, T16B, v11, v12, v2);
+
+    pmull (v13, T1Q, v3, v0, T1D);
+    pmull2(v14, T1Q, v3, v0, T2D);
+    ldrq(v3, Address(buf, 0x30));
+    eor3(v3, T16B, v13, v14, v3);
+
+    pmull (v15, T1Q, v4, v0, T1D);
+    pmull2(v16, T1Q, v4, v0, T2D);
+    ldrq(v4, Address(buf, 0x40));
+    eor3(v4, T16B, v15, v16, v4);
+
+    pmull (v17, T1Q, v5, v0, T1D);
+    pmull2(v18, T1Q, v5, v0, T2D);
+    ldrq(v5, Address(buf, 0x50));
+    eor3(v5, T16B, v17, v18, v5);
+
+    pmull (v19, T1Q, v6, v0, T1D);
+    pmull2(v20, T1Q, v6, v0, T2D);
+    ldrq(v6, Address(buf, 0x60));
+    eor3(v6, T16B, v19, v20, v6);
+
+    pmull (v21, T1Q, v7, v0, T1D);
+    pmull2(v22, T1Q, v7, v0, T2D);
+    ldrq(v7, Address(buf, 0x70));
+    eor3(v7, T16B, v21, v22, v7);
+
+    pmull (v23, T1Q, v8, v0, T1D);
+    pmull2(v24, T1Q, v8, v0, T2D);
+    ldrq(v8, Address(pre(buf, 0x80)));
+    eor3(v8, T16B, v23, v24, v8);
+
+    subs(len, len, 0x80);
+    br(Assembler::GE, CRC_by128_loop);
+
+    // fold into 512 bits
+    ldrq(v0, Address(table, 0x10));
+
+    pmull (v10,  T1Q, v1, v0, T1D);
+    pmull2(v11, T1Q, v1, v0, T2D);
+    eor3(v1, T16B, v10, v11, v5);
+
+    pmull (v12, T1Q, v2, v0, T1D);
+    pmull2(v13, T1Q, v2, v0, T2D);
+    eor3(v2, T16B, v12, v13, v6);
+
+    pmull (v14, T1Q, v3, v0, T1D);
+    pmull2(v15, T1Q, v3, v0, T2D);
+    eor3(v3, T16B, v14, v15, v7);
+
+    pmull (v16, T1Q, v4, v0, T1D);
+    pmull2(v17, T1Q, v4, v0, T2D);
+    eor3(v4, T16B, v16, v17, v8);
+
+    // fold into 128 bits
+    ldrq(v5, Address(table, 0x20));
+    pmull (v10, T1Q, v1, v5, T1D);
+    pmull2(v11, T1Q, v1, v5, T2D);
+    eor3(v4, T16B, v4, v10, v11);
+
+    ldrq(v6, Address(table, 0x30));
+    pmull (v12, T1Q, v2, v6, T1D);
+    pmull2(v13, T1Q, v2, v6, T2D);
+    eor3(v4, T16B, v4, v12, v13);
+
+    ldrq(v7, Address(table, 0x40));
+    pmull (v14, T1Q, v3, v7, T1D);
+    pmull2(v15, T1Q, v3, v7, T2D);
+    eor3(v1, T16B, v4, v14, v15);
+
+    add(len, len, 0x80);
+    add(buf, buf, 0x10);
+
+    mov(tmp0, v1, T2D, 0);
+    mov(tmp1, v1, T2D, 1);
+}
 
 SkipIfEqual::SkipIfEqual(
     MacroAssembler* masm, const bool* flag_addr, bool value) {

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.hpp
@@ -1310,12 +1310,18 @@ public:
                                Register yz_idx1, Register yz_idx2,
                                Register tmp, Register tmp3, Register tmp4,
                                Register tmp7, Register product_hi);
+  void kernel_crc32_using_crypto_pmull(Register crc, Register buf,
+        Register len, Register tmp0, Register tmp1, Register tmp2,
+        Register tmp3);
   void kernel_crc32_using_crc32(Register crc, Register buf,
         Register len, Register tmp0, Register tmp1, Register tmp2,
         Register tmp3);
   void kernel_crc32c_using_crc32c(Register crc, Register buf,
         Register len, Register tmp0, Register tmp1, Register tmp2,
         Register tmp3);
+  void kernel_crc32_common_fold_using_crypto_pmull(Register crc, Register buf,
+        Register len, Register tmp0, Register tmp1, Register tmp2,
+        size_t table_offset);
 public:
   void multiply_to_len(Register x, Register xlen, Register y, Register ylen, Register z,
                        Register zlen, Register tmp1, Register tmp2, Register tmp3,

--- a/src/hotspot/cpu/aarch64/stubRoutines_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/stubRoutines_aarch64.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2014, Red Hat Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -290,6 +290,18 @@ ATTRIBUTE_ALIGNED(4096) juint StubRoutines::aarch64::_crc_table[] =
     0xED78D502UL, 0x62EDAE7DUL,         // byte swap
     0x02D578EDUL, 0x7DAEED62UL,         // word swap
     0xD502ED78UL, 0xAE7D62EDUL,         // byte swap of word swap
+
+    // Constants for CRC-32 crypto pmull implementation
+    0xe88ef372UL, 0x00000001UL,
+    0x4a7fe880UL, 0x00000001UL,
+    0x54442bd4UL, 0x00000001UL,
+    0xc6e41596UL, 0x00000001UL,
+    0x3db1ecdcUL, 0x00000000UL,
+    0x74359406UL, 0x00000001UL,
+    0xf1da05aaUL, 0x00000000UL,
+    0x5a546366UL, 0x00000001UL,
+    0x751997d0UL, 0x00000001UL,
+    0xccaa009eUL, 0x00000000UL,
 };
 
 // Accumulation coefficients for adler32 upper 16 bits

--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
@@ -248,6 +248,18 @@ void VM_Version::initialize() {
     FLAG_SET_DEFAULT(UseCRC32, false);
   }
 
+  // Neoverse V1
+  if (_cpu == CPU_ARM && (_model == 0xd40 || _model2 == 0xd40)) {
+    if (FLAG_IS_DEFAULT(UseCryptoPmullForCRC32)) {
+      FLAG_SET_DEFAULT(UseCryptoPmullForCRC32, true);
+    }
+  }
+
+  if (UseCryptoPmullForCRC32 && ((_features & CPU_PMULL) == 0 || (_features & CPU_SHA3) == 0 || (_features & CPU_CRC32) == 0)) {
+    warning("UseCryptoPmullForCRC32 specified, but not supported on this CPU");
+    FLAG_SET_DEFAULT(UseCryptoPmullForCRC32, false);
+  }
+
   if (FLAG_IS_DEFAULT(UseAdler32Intrinsics)) {
     FLAG_SET_DEFAULT(UseAdler32Intrinsics, true);
   }


### PR DESCRIPTION
### Description

Backport [JDK-8302113](https://bugs.openjdk.org/browse/JDK-8302113)

The backport differs from the original one in checking CPU features and moving between general-purpose and floating-point registers.

### Related issues


### Motivation and context


### How has this been tested?

The following tests passed.
```
test/jdk/java/util/zip/TestCRC32.java
test/hotspot/jtreg/compiler/intrinsics/zip/TestCRC32.java
```

### Platform information

AArch64

### Additional context
