### PR TITLE
Add experimental flag for AL packaging

### DIFF
--- a/installers/linux/al2/spec/build.gradle
+++ b/installers/linux/al2/spec/build.gradle
@@ -50,7 +50,8 @@ task inflateRpmSpec {
                     build_id            : buildId,
                     release_id          : releaseId,
                     version_opt         : versionOpt,
-                    debug_level         : correttoDebugLevel
+                    debug_level         : correttoDebugLevel,
+                    experimental_feature: project.findProperty("corretto.experimental_feature") ?: "%{nil}"
                 ])
         outputs.files.singleFile.text = renderedTemplate
     }

--- a/installers/linux/al2/spec/java-amazon-corretto.spec.template
+++ b/installers/linux/al2/spec/java-amazon-corretto.spec.template
@@ -26,6 +26,14 @@
 %global build_id        $build_id
 %global release_id      $release_id
 %global version_opt     $version_opt
+%global experimental_feature     $experimental_feature
+
+# The experimental_feature macro gets set to %nil by the template, but that is still defined and
+# the spec doesn't have a quick is not nil check, just define/not defined, this makes it easier to
+# work with
+%if 0%{?experimental_feature:1} && "%{experimental_feature}" == "%{nil}"
+%undefine experimental_feature
+%endif
 # If we need to rev the package for something outside of what the
 # Corretto team is doing, we can define release_ext.
 # %global release_ext  1
@@ -74,7 +82,7 @@
 %bcond_without bootjdk
 
 Summary: Amazon Corretto development environment
-Name: java-${java_spec_version}-amazon-corretto
+Name: java-${java_spec_version}-amazon-corretto%{?experimental_feature:-%{experimental_feature}}
 # Matches the 'full version' from Java's release notes:
 # https://www.oracle.com/technetwork/java/javase/11-0-2-relnotes-5188746.html
 # Eg: 11.0.2+7


### PR DESCRIPTION
Adding a new corretto.experimental_feature that will be added to the AL RPM names and provides/requires.

### Testing

Built the RPMs locally with
```
./gradlew :installers:linux:al2:spec:rpmBuild -Pcorretto.debug_level=release -Pcorretto.experimental_feature=foobar

rpmbuild  --rebuild ./installers/linux/al2/spec/corretto-build/distributions/java-17-amazon-corretto-foobar-17.0.7+7-1.amzn2.1.src.rpm
```

Then checked the resulting RPMs for the updated values:

```
ls ~/rpmbuild/RPMS/x86_64/java-17-amazon-corretto-foobar-*
/home/lutkerd/rpmbuild/RPMS/x86_64/java-17-amazon-corretto-foobar-17.0.7+7-1.amzn2int.1.x86_64.rpm           /home/lutkerd/rpmbuild/RPMS/x86_64/java-17-amazon-corretto-foobar-javadoc-17.0.7+7-1.amzn2int.1.x86_64.rpm
/home/lutkerd/rpmbuild/RPMS/x86_64/java-17-amazon-corretto-foobar-devel-17.0.7+7-1.amzn2int.1.x86_64.rpm     /home/lutkerd/rpmbuild/RPMS/x86_64/java-17-amazon-corretto-foobar-jmods-17.0.7+7-1.amzn2int.1.x86_64.rpm
/home/lutkerd/rpmbuild/RPMS/x86_64/java-17-amazon-corretto-foobar-headless-17.0.7+7-1.amzn2int.1.x86_64.rpm
```

```
$ rpm -qp --provides ~/rpmbuild/RPMS/x86_64/java-17-amazon-corretto-foobar-*
java = 1:17.0.7
java-17 = 1:17.0.7
java-17 = 1:17.0.7+7-1.amzn2int.1
java-17-amazon-corretto-foobar = 1:17.0.7+7-1.amzn2int.1
java-17-amazon-corretto-foobar(x86-64) = 1:17.0.7+7-1.amzn2int.1
jre = 17.0.7
jre-17 = 1:17.0.7+7-1.amzn2int.1
jre-17-amazon-corretto = 1:17.0.7+7-1.amzn2int.1
java-17-amazon-corretto-foobar-devel = 1:17.0.7+7-1.amzn2int.1
java-17-amazon-corretto-foobar-devel(x86-64) = 1:17.0.7+7-1.amzn2int.1
java-17-devel = 1:17.0.7
java-17-devel = 1:17.0.7+7-1.amzn2int.1
java-devel = 1:17.0.7
config(java-17-amazon-corretto-foobar-headless) = 1:17.0.7+7-1.amzn2int.1
java-17-amazon-corretto-foobar-headless = 1:17.0.7+7-1.amzn2int.1
java-17-amazon-corretto-foobar-headless(x86-64) = 1:17.0.7+7-1.amzn2int.1
java-17-headless = 1:17.0.7+7-1.amzn2int.1
java-headless = 1:17.0.7
jre-17-amazon-corretto-headless = 1:17.0.7+7-1.amzn2int.1
jre-17-headless = 1:17.0.7+7-1.amzn2int.1
jre-headless = 1:17.0.7
java-17-amazon-corretto-foobar-javadoc = 1:17.0.7+7-1.amzn2int.1
java-17-amazon-corretto-foobar-javadoc(x86-64) = 1:17.0.7+7-1.amzn2int.1
java-17-javadoc = 1:17.0.7+7-1.amzn2int.1
java-javadoc = 1:17.0.7+7-1.amzn2int.1
java-17-amazon-corretto-foobar-jmods = 1:17.0.7+7-1.amzn2int.1
java-17-amazon-corretto-foobar-jmods(x86-64) = 1:17.0.7+7-1.amzn2int.1
java-17-jmods = 1:17.0.7
java-17-jmods = 1:17.0.7+7-1.amzn2int.1
```
```
$ rpm -qp --requires ~/rpmbuild/RPMS/x86_64/java-17-amazon-corretto-foobar-*
libX11
libXi
libXinerama
libXt
libXrender
libXrandr
libXtst
giflib
libpng
java-17-amazon-corretto-foobar-headless(x86-64) = 1:17.0.7+7-1.amzn2int.1
rpmlib(FileDigests) <= 4.6.0-1
rpmlib(PayloadFilesHavePrefix) <= 4.0-1
rpmlib(CompressedFileNames) <= 3.0.4-1
rpmlib(PayloadIsXz) <= 5.2-1
java-17-amazon-corretto-foobar-headless(x86-64) = 1:17.0.7+7-1.amzn2int.1
/bin/sh
/bin/sh
rpmlib(FileDigests) <= 4.6.0-1
rpmlib(PayloadFilesHavePrefix) <= 4.0-1
rpmlib(CompressedFileNames) <= 3.0.4-1
rpmlib(PayloadIsXz) <= 5.2-1
jpackage-utils
zlib
fontconfig
freetype
dejavu-sans-fonts
dejavu-serif-fonts
dejavu-sans-mono-fonts
alsa-lib
libjpeg
ca-certificates
chkconfig
chkconfig
/bin/sh
/bin/sh
rpmlib(FileDigests) <= 4.6.0-1
rpmlib(PayloadFilesHavePrefix) <= 4.0-1
rpmlib(CompressedFileNames) <= 3.0.4-1
rpmlib(PayloadIsXz) <= 5.2-1
rpmlib(CompressedFileNames) <= 3.0.4-1
rpmlib(FileDigests) <= 4.6.0-1
rpmlib(PayloadFilesHavePrefix) <= 4.0-1
rpmlib(PayloadIsXz) <= 5.2-1
java-17-amazon-corretto-foobar-devel(x86-64) = 1:17.0.7+7-1.amzn2int.1
rpmlib(CompressedFileNames) <= 3.0.4-1
rpmlib(FileDigests) <= 4.6.0-1
rpmlib(PayloadFilesHavePrefix) <= 4.0-1
rpmlib(PayloadIsXz) <= 5.2-1
```