### PR TITLE
Adding way to pass configure options on AL builds

### DIFF
--- a/installers/linux/al2/spec/build.gradle
+++ b/installers/linux/al2/spec/build.gradle
@@ -51,7 +51,8 @@ task inflateRpmSpec {
                     release_id          : releaseId,
                     version_opt         : versionOpt,
                     debug_level         : correttoDebugLevel,
-                    experimental_feature: project.findProperty("corretto.experimental_feature") ?: "%{nil}"
+                    experimental_feature: project.findProperty("corretto.experimental_feature") ?: "%{nil}",
+                    additional_configure_options: project.findProperty("corretto.additional_configure_options") ?: "%{nil}"
                 ])
         outputs.files.singleFile.text = renderedTemplate
     }

--- a/installers/linux/al2/spec/java-amazon-corretto.spec.template
+++ b/installers/linux/al2/spec/java-amazon-corretto.spec.template
@@ -27,12 +27,17 @@
 %global release_id      $release_id
 %global version_opt     $version_opt
 %global experimental_feature     $experimental_feature
+%global additional_configure_options     $additional_configure_options
 
 # The experimental_feature macro gets set to %nil by the template, but that is still defined and
 # the spec doesn't have a quick is not nil check, just define/not defined, this makes it easier to
 # work with
 %if 0%{?experimental_feature:1} && "%{experimental_feature}" == "%{nil}"
 %undefine experimental_feature
+%endif
+
+%if 0%{?additional_configure_options:1} == 1 && "%{additional_configure_options}" == "%{nil}"
+%undefine additional_configure_options
 %endif
 # If we need to rev the package for something outside of what the
 # Corretto team is doing, we can define release_ext.
@@ -248,6 +253,9 @@ bash ./configure \\
 %if "%{?GIFLIB_DEFINE:1}" == "1"
         --with-extra-cflags="%{GIFLIB_DEFINE}" \\
 %endif
+%if 0%{?additional_configure_options:1}
+        %{additional_configure_options} \\
+%endif
 %endif
         --with-jvm-features="zgc shenandoahgc" \\
         --with-version-feature="${java_spec_version}" \\
@@ -258,7 +266,7 @@ bash ./configure \\
         --with-zlib=system \\
         --with-version-opt="%{version_opt}" \\
         --with-version-build="%{build_id}" \\
-        --with-vendor-version-string="Corretto-%{java_version}.%{build_id}.%{release_id}" \\
+        --with-vendor-version-string="Corretto%{?experimental_feature:-%{experimental_feature}}-%{java_version}.%{build_id}.%{release_id}" \\
         --with-version-pre= \\
         --with-vendor-name="Amazon.com Inc." \\
         --with-vendor-url="https://aws.amazon.com/corretto/" \\


### PR DESCRIPTION
Can pass flags to configure when building RPMs for AmazonLinux. Also adding the experimental_feature to the output of java -version

I will merge up to CorrettoJDK and then backport to 11 and 8.

### How has this been tested?
Ran through automation and it is working to pass the correct flags and updated the java -version string correctly.
