### PR TITLE
Adding provides 'jre-17' to generic RPM

### DIFF
--- a/installers/linux/universal/rpm/build.gradle
+++ b/installers/linux/universal/rpm/build.gradle
@@ -120,6 +120,11 @@ task generateJdkRpm(type: Rpm) {
     provides('java-17-openjdk-devel', "${epoch}:${version}-${release}", EQUAL)
     provides('java-sdk-17', "${epoch}:${version}", EQUAL)
     provides('java-sdk-17-openjdk ', "${epoch}:${version}-${release}", EQUAL)
+    provides('java-17', "${epoch}:${version}", EQUAL)
+    provides('java-17-openjdk', "${epoch}:${version}", EQUAL)
+    provides('jre', "${epoch}:${version}", EQUAL)
+    provides('jre-17', "${epoch}:${version}", EQUAL)
+    provides('jre-17-openjdk', "${epoch}:${version}", EQUAL)
 
     from(jdkBinaryDir) {
         include(project.configurationFiles)


### PR DESCRIPTION
Fix for https://github.com/corretto/corretto-17/issues/102

Local build was correct with full set of provides:
```
$ rpm -qp java-17-amazon-corretto-devel-17.0.8.6-1.x86_64.rpm --provides
java-17-amazon-corretto-devel = 1:17.0.8.6-1
java-17-devel = 1:17.0.8.6
java-17-openjdk-devel = 1:17.0.8.6-1
java-sdk-17 = 1:17.0.8.6
java-sdk-17-openjdk  = 1:17.0.8.6-1
java-17 = 1:17.0.8.6
java-17-openjdk = 1:17.0.8.6
jre = 1:17.0.8.6
jre-17 = 1:17.0.8.6
jre-17-openjdk = 1:17.0.8.6
```