### PR TITLE
AL: Adding options for GCC version and zlib bundling

### DIFF
--- a/installers/linux/al2/spec/build.gradle
+++ b/installers/linux/al2/spec/build.gradle
@@ -52,7 +52,9 @@ task inflateRpmSpec {
                     version_opt         : versionOpt,
                     debug_level         : correttoDebugLevel,
                     experimental_feature: project.findProperty("corretto.experimental_feature") ?: "%{nil}",
-                    additional_configure_options: project.findProperty("corretto.additional_configure_options") ?: "%{nil}"
+                    additional_configure_options: project.findProperty("corretto.additional_configure_options") ?: "%{nil}",
+                    zlib_option: project.findProperty("corretto.zlib_option") ?: "system",
+                    use_gcc_ver: project.findProperty("corretto.use_gcc_ver") ?: ""
                 ])
         outputs.files.singleFile.text = renderedTemplate
     }

--- a/installers/linux/al2/spec/java-amazon-corretto.spec.template
+++ b/installers/linux/al2/spec/java-amazon-corretto.spec.template
@@ -28,6 +28,8 @@
 %global version_opt     $version_opt
 %global experimental_feature     $experimental_feature
 %global additional_configure_options     $additional_configure_options
+%global zlib_option $zlib_option
+%global use_gcc_ver $use_gcc_ver
 
 # The experimental_feature macro gets set to %nil by the template, but that is still defined and
 # the spec doesn't have a quick is not nil check, just define/not defined, this makes it easier to
@@ -120,7 +122,7 @@ BuildRequires: cups-devel
 BuildRequires: fontconfig-devel
 BuildRequires: freetype-devel
 BuildRequires: giflib-devel
-BuildRequires: gcc-c++
+BuildRequires: gcc%{?use_gcc_ver}-c++
 BuildRequires: libjpeg-devel
 BuildRequires: libpng-devel
 BuildRequires: libxslt
@@ -253,9 +255,9 @@ bash ./configure \\
 %if "%{?GIFLIB_DEFINE:1}" == "1"
         --with-extra-cflags="%{GIFLIB_DEFINE}" \\
 %endif
+%endif
 %if 0%{?additional_configure_options:1}
         %{additional_configure_options} \\
-%endif
 %endif
         --with-jvm-features="zgc shenandoahgc" \\
         --with-version-feature="${java_spec_version}" \\
@@ -263,7 +265,7 @@ bash ./configure \\
         --with-libjpeg=system \\
         --with-giflib=system \\
         --with-libpng=system \\
-        --with-zlib=system \\
+        --with-zlib="%{zlib_option}" \\
         --with-version-opt="%{version_opt}" \\
         --with-version-build="%{build_id}" \\
         --with-vendor-version-string="Corretto%{?experimental_feature:-%{experimental_feature}}-%{java_version}.%{build_id}.%{release_id}" \\


### PR DESCRIPTION
Adding option to specifying the GCC version to build with so we can start testing with newer compilers as well as using system/bundled zlib.