### PR TITLE
AL: Fix gcc version check when unset

### DIFF
--- a/installers/linux/al2/spec/build.gradle
+++ b/installers/linux/al2/spec/build.gradle
@@ -54,7 +54,7 @@ task inflateRpmSpec {
                     experimental_feature: project.findProperty("corretto.experimental_feature") ?: "%{nil}",
                     additional_configure_options: project.findProperty("corretto.additional_configure_options") ?: "%{nil}",
                     zlib_option: project.findProperty("corretto.zlib_option") ?: "system",
-                    use_gcc_ver: project.findProperty("corretto.use_gcc_ver") ?: ""
+                    use_gcc_ver: project.findProperty("corretto.use_gcc_ver") ?: "%{nil}"
                 ])
         outputs.files.singleFile.text = renderedTemplate
     }

--- a/installers/linux/al2/spec/java-amazon-corretto.spec.template
+++ b/installers/linux/al2/spec/java-amazon-corretto.spec.template
@@ -41,6 +41,10 @@
 %if 0%{?additional_configure_options:1} == 1 && "%{additional_configure_options}" == "%{nil}"
 %undefine additional_configure_options
 %endif
+
+%if 0%{?use_gcc_ver:1} == 1 && "%{use_gcc_ver}" == "%{nil}"
+%undefine use_gcc_ver
+%endif
 # If we need to rev the package for something outside of what the
 # Corretto team is doing, we can define release_ext.
 # %global release_ext  1


### PR DESCRIPTION
Generated the rpm with the value set to 10 and unset and checked the GCC requires

Previous testing of wasn't sufficient.