### PR TITLE
JDK-11024: [GenShen Preview] Create a special version string for genshen

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,4 @@
 org.gradle.parallel=true
+
+// GenShen pre-GA special version string
+corretto.versionOpt="Experimental_GenShen_Preview_Alpha"


### PR DESCRIPTION
This PR is specifically targeted to the generational-shenandoah branch of the corretto-17 project repository.

To distinguish Generational Shenandoah Preview builds from other Corretto-17 builds, they will advertise a special version string:
```
% ./installers/linux/universal/tar/corretto-build/buildRoot/build/linux-x86_64-server-release/jdk/bin/java -version
openjdk version "17.0.9" 2023-10-17
OpenJDK Runtime Environment Corretto-17.0.9.7.1 (build 17.0.9+7-ExperimentalGenShenPreviewAlpha)
OpenJDK 64-Bit Server VM Corretto-17.0.9.7.1 (build 17.0.9+7-ExperimentalGenShenPreviewAlpha, mixed mode)
```

Thanks to Dan Lutker and William Kemper for their help with this.