### PR TITLE
Alpine build failure

### DIFF
--- a/src/hotspot/cpu/aarch64/interpreterRT_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/interpreterRT_aarch64.cpp
@@ -267,7 +267,7 @@ class SlowSignatureHandler
 
   virtual void pass_object() {
     intptr_t* addr = single_slot_addr();
-    intptr_t value = *addr == 0 ? NULL : (intptr_t)addr;
+    intptr_t value = *addr == 0 ? nullptr : (intptr_t)addr;
     if (pass_gpr(value) < 0) {
       pass_stack<>(value);
     }

--- a/src/hotspot/cpu/aarch64/interpreterRT_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/interpreterRT_aarch64.cpp
@@ -267,7 +267,7 @@ class SlowSignatureHandler
 
   virtual void pass_object() {
     intptr_t* addr = single_slot_addr();
-    intptr_t value = *addr == 0 ? 0 : (intptr_t)addr;
+    intptr_t value = *addr == 0 ? (intptr_t)0 : (intptr_t)addr;
     if (pass_gpr(value) < 0) {
       pass_stack<>(value);
     }

--- a/src/hotspot/cpu/aarch64/interpreterRT_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/interpreterRT_aarch64.cpp
@@ -267,7 +267,7 @@ class SlowSignatureHandler
 
   virtual void pass_object() {
     intptr_t* addr = single_slot_addr();
-    intptr_t value = *addr == 0 ? nullptr : (intptr_t)addr;
+    intptr_t value = *addr == 0 ? 0 : (intptr_t)addr;
     if (pass_gpr(value) < 0) {
       pass_stack<>(value);
     }


### PR DESCRIPTION
### Description
Addresing Alpine build failure.
Whole patch is too large to backport so I am only fixing this line to pass build issue


### Related issues
https://bugs.openjdk.org/browse/JDK-8301493

### Motivation and context


### How has this been tested?

Tested on mac , generic linux and alpine aarch 64
### Platform information



### Additional context
