### PR TITLE
Update rpm provides

### DIFF
--- a/installers/linux/universal/rpm/build.gradle
+++ b/installers/linux/universal/rpm/build.gradle
@@ -115,6 +115,7 @@ task generateJdkRpm(type: Rpm) {
     requires('zlib')
 
     provides(jdkPackageName, "${epoch}:${version}-${release}", EQUAL)
+    provides("java", "${epoch}:${version}-${release}", EQUAL)
     provides('java-17-devel', "${epoch}:${version}", EQUAL)
     provides('java-17-openjdk-devel', "${epoch}:${version}", EQUAL)
     provides('java-17-openjdk-devel', "${epoch}:${version}-${release}", EQUAL)


### PR DESCRIPTION
Clean backport of [corretto-jdk#112](https://github.com/corretto/corretto-jdk/pull/112) to resolve [corretto-21#30](https://github.com/corretto/corretto-21/issues/30)