### PR TITLE
8321105: Enable UseCryptoPmullForCRC32 for Neoverse V2

### DIFF
--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
@@ -204,7 +204,11 @@ void VM_Version::initialize() {
     }
   }
 
-  // Neoverse N1, N2, V1, V2
+  // Neoverse
+  //   N1: 0xd0c
+  //   N2: 0xd49
+  //   V1: 0xd40
+  //   V2: 0xd4f
   if (_cpu == CPU_ARM && (model_is(0xd0c) || model_is(0xd49) ||
                           model_is(0xd40) || model_is(0xd4f))) {
     if (FLAG_IS_DEFAULT(UseSIMDForMemoryOps)) {
@@ -246,8 +250,10 @@ void VM_Version::initialize() {
     FLAG_SET_DEFAULT(UseCRC32, false);
   }
 
-  // Neoverse V1
-  if (_cpu == CPU_ARM && (_model == 0xd40 || _model2 == 0xd40)) {
+  // Neoverse
+  //   V1: 0xd40
+  //   V2: 0xd4f
+  if (_cpu == CPU_ARM && (model_is(0xd40) || model_is(0xd4f))) {
     if (FLAG_IS_DEFAULT(UseCryptoPmullForCRC32)) {
       FLAG_SET_DEFAULT(UseCryptoPmullForCRC32, true);
     }


### PR DESCRIPTION
Backport-of openjdk/jdk@5b02188f