### PR TITLE
Remove the duplicate operation logic of Stream.toList

### DIFF
--- a/src/java.base/share/classes/java/util/stream/Stream.java
+++ b/src/java.base/share/classes/java/util/stream/Stream.java
@@ -1183,7 +1183,7 @@ public interface Stream<T> extends BaseStream<T, Stream<T>> {
      *
      * @implSpec The implementation in this interface returns a List produced as if by the following:
      * <pre>{@code
-     * Collections.unmodifiableList(new ArrayList<>(Arrays.asList(this.toArray())))
+     * Collections.unmodifiableList(Arrays.asList(this.toArray()))
      * }</pre>
      *
      * @implNote Most instances of Stream will override this method and provide an implementation
@@ -1195,7 +1195,7 @@ public interface Stream<T> extends BaseStream<T, Stream<T>> {
      */
     @SuppressWarnings("unchecked")
     default List<T> toList() {
-        return (List<T>) Collections.unmodifiableList(new ArrayList<>(Arrays.asList(this.toArray())));
+        return (List<T>) Collections.unmodifiableList(Arrays.asList(this.toArray()));
     }
 
     /**


### PR DESCRIPTION
## Related Issue
#179 

## PR Point

### Arrays.asList
```java
@SafeVarargs
    @SuppressWarnings("varargs")
    public static <T> List<T> asList(T... a) {
        return new ArrayList<>(a);
    }
```
The `Arrays.asList` logic generates an `ArrayList` using the received parameters and returns it.

<br>

### Stream.toList
```java
default List<T> toList() {
        return (List<T>) Collections.unmodifiableList(new ArrayList<>(Arrays.asList(this.toArray())));
    }
```
However, `Stream.toList` calls `Arrays.asList` and calls `new ArrayList` again.
It seemed to me that these logics were performing overlapping tasks.

<br>

## Change

### Changed Stream.toList
```java
default List<T> toList() {
        return (List<T>) Collections.unmodifiableList(Arrays.asList(this.toArray()));
    }
```
So I changed this logic like this.