### PR TITLE
Remove jtreg dependency for windows build

### DIFF
--- a/installers/windows/zip/build.gradle
+++ b/installers/windows/zip/build.gradle
@@ -43,7 +43,6 @@ task configureBuild(type: Exec) {
     def command = ['bash', 'configure',
            "--with-cacerts-file=${depsMap[caCerts]}",
            "--with-boot-jdk=${project.getProperty('bootjdk_dir')}",
-           "--with-jtreg=${project.getProperty('jtreg_dir')}",
            "--with-zlib=bundled"
     ]
     // Common flags


### PR DESCRIPTION

### Description
Backport of https://github.com/corretto/corretto-jdk/pull/124