### PR TITLE
8352302: Test sun/security/tools/jarsigner/TimestampCheck.java is failing

### DIFF
--- a/test/jdk/sun/security/tools/jarsigner/TimestampCheck.java
+++ b/test/jdk/sun/security/tools/jarsigner/TimestampCheck.java
@@ -888,7 +888,7 @@ public class TimestampCheck {
         }
 
         gencert("tsold", "-ext eku:critical=ts -startdate -40d -validity 500");
-        gencert("tsbefore2019", "-ext eku:critical=ts -startdate 2018/01/01 -validity 3000");
+        gencert("tsbefore2019", "-ext eku:critical=ts -startdate 2018/01/01 -validity 5000");
 
         gencert("tsweak", "-ext eku:critical=ts");
         gencert("tsdisabled", "-ext eku:critical=ts");


### PR DESCRIPTION
Cherrypicking fix for [JDK-8352302](https://bugs.openjdk.org/browse/JDK-8352302), which addresses failure with `TimestampCheck.java`: A certificate created in the test will expire on 2026-03-20. This change adds another 2000 days to it. Ran test locally to confirm passing.