### PR TITLE
8353013: java.net.URI.create(String) may have low performance to scan…

### DIFF
--- a/src/java.base/share/classes/java/net/URI.java
+++ b/src/java.base/share/classes/java/net/URI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -3406,6 +3406,19 @@ public final class URI
             int p = start;
             int q = scan(p, n, L_DIGIT, H_DIGIT);
             if (q <= p) return q;
+
+            // Handle leading zeros
+            int i = p, j;
+            while ((j = scan(i, q, '0')) > i) i = j;
+
+            // Calculate the number of significant digits (after leading zeros)
+            int significantDigitsNum = q - i;
+
+            if (significantDigitsNum < 3)  return q; // definitely < 255
+
+            // If more than 3 significant digits, it's definitely > 255
+            if (significantDigitsNum > 3) return p;
+
             if (Integer.parseInt(input, p, q, 10) > 255) return p;
             return q;
         }

--- a/test/jdk/java/net/URI/Test.java
+++ b/test/jdk/java/net/URI/Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,7 +24,7 @@
 /* @test
  * @summary Unit test for java.net.URI
  * @bug 4464135 4505046 4503239 4438319 4991359 4866303 7023363 7041800
- *      7171415 6339649 6933879 8037396 8272072
+ *      7171415 6339649 6933879 8037396 8272072 8353013
  * @author Mark Reinhold
  */
 
@@ -1618,6 +1618,53 @@ public class Test {
         b6933879();
         b8037396();
         b8272072();
+        b8353013();
+    }
+
+    private static void b8297687() {
+        // constructors that take a hostname should fail
+        test("ftps", "p.e.local|SIT@p.e.local", "/path", null)
+                .x().z();
+        test("ftps", null,"p.e.local|SIT@p.e.local", -1, "/path", null, null)
+                .x().z();
+        // constructors that take an authority component should succeed
+        test("ftps", "p.e.local|SIT@p.e.local", "/path", null,null)
+                .s("ftps")
+                .sp("//p.e.local%7CSIT@p.e.local/path")
+                .spd("//p.e.local|SIT@p.e.local/path")
+                .u("p.e.local%7CSIT")
+                .ud("p.e.local|SIT")
+                .h("p.e.local")
+                .n(-1)
+                .p("/path")
+                .pd("/path")
+                .z();
+
+        // check index in exception for constructors that should fail
+        try {
+            URI uri = new URI("ftps", "p.e.local|SIT@p.e.local", "/path", null);
+            throw new AssertionError("Expected URISyntaxException not thrown for " + uri);
+        } catch (URISyntaxException ex) {
+            if (ex.getMessage().contains("at index 16")) {
+                 System.out.println("Got expected exception: " + ex);
+            } else {
+                throw new AssertionError("Exception does not point at index 16", ex);
+            }
+        }
+        testCount++;
+
+        // check index in exception for constructors that should fail
+        try {
+            URI uri = new URI("ftps", null, "p.e.local|SIT@p.e.local", -1, "/path", null, null);
+            throw new AssertionError("Expected URISyntaxException not thrown for " + uri);
+        } catch (URISyntaxException ex) {
+            if (ex.getMessage().contains("at index 16")) {
+                System.out.println("Got expected exception: " + ex);
+            } else {
+                throw new AssertionError("Exception does not point at index 16", ex);
+            }
+        }
+        testCount++;
     }
 
     // 6339649 - include detail message from nested exception
@@ -1693,6 +1740,39 @@ public class Test {
         } catch (URISyntaxException e) {
             throw new AssertionError("shouldn't ever happen", e);
         }
+    }
+
+    // 8353013 - Increase test coverage for cases where the authority component of a hierarchical
+    // URI has a host component that starts with a number.
+    private static void b8353013() {
+        testCreate("https://0.0.0.1").s("https").h("0.0.0.1").p("").z();
+        testCreate("https://00.0.0.2").s("https").h("00.0.0.2").p("").z();
+        testCreate("https://000.0.0.3").s("https").h("000.0.0.3").p("").z();
+        testCreate("https://0000.0.0.4").s("https").h("0000.0.0.4").p("").z();
+
+        testCreate("https://00000.0.0.5").s("https").h("00000.0.0.5").p("").z();
+        testCreate("https://00001.0.0.6").s("https").h("00001.0.0.6").p("").z();
+
+        testCreate("https://01.0.0.1").s("https").h("01.0.0.1").p("").z();
+
+        testCreate("https://111111.2.3.com").s("https").h("111111.2.3.com").p("").z();
+
+        testCreate("https://1.example.com").s("https").h("1.example.com").p("").z();
+        testCreate("https://12.example.com").s("https").h("12.example.com").p("").z();
+        testCreate("https://123.example.com").s("https").h("123.example.com").p("").z();
+        testCreate("https://1234.example.com").s("https").h("1234.example.com").p("").z();
+        testCreate("https://12345.example.com").s("https").h("12345.example.com").p("").z();
+
+        testCreate("https://98765432101.example.com").s("https").h("98765432101.example.com").p("").z();
+        testCreate("https://98765432101.www.example.com/").s("https").h("98765432101.www.example.com").p("/").z();
+        testCreate("https://98765432101.www.example.com").s("https").h("98765432101.www.example.com").p("").z();
+
+        testCreate("https://9223372036854775808.example.com").s("https").h("9223372036854775808.example.com").p("").z();
+        testCreate("https://9223372036854775808.www.example.com").s("https").h("9223372036854775808.www.example.com").p("").z();
+        testCreate("https://9223372036854775808.xyz.abc.com").s("https").h("9223372036854775808.xyz.abc.com").p("").z();
+        testCreate("https://9223372036854775808.xyz.abc.pqr.com").s("https").h("9223372036854775808.xyz.abc.pqr.com").p("").z();
+
+        testCreate("https://256.example.com").s("https").h("256.example.com").p("").z();
     }
 
     public static void main(String[] args) throws Exception {

--- a/test/micro/org/openjdk/bench/java/net/URIAuthorityParsingBenchmark.java
+++ b/test/micro/org/openjdk/bench/java/net/URIAuthorityParsingBenchmark.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.bench.java.net;
+
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.net.URI;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Tests Java.net.URI.create performance on various URI types.
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Benchmark)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(value = 3)
+public class URIAuthorityParsingBenchmark {
+
+    @Param({
+            "https://98765432101.abc.xyz.com",
+            "https://ABCDEFGHIJK.abc.xyz.com"
+    })
+    private String uri;
+
+    @Benchmark
+    public void create(Blackhole blackhole) {
+        blackhole.consume(URI.create(uri));
+    }
+
+}


### PR DESCRIPTION
### Description
Backport for https://bugs.openjdk.org/browse/JDK-8353013. [Original commit in tip](https://github.com/openjdk/jdk/commit/84458ec18ce33295636f7b26b8e3ff25ecb349f2).

Not a clean backport. It requires [JDK-8051627](https://bugs.openjdk.org/browse/JDK-8051627) and [JDK-8297687](https://bugs.openjdk.org/browse/JDK-8297687) to be clean. However, [JDK-8051627](https://bugs.openjdk.org/browse/JDK-8051627) has behavioral changes. I'd like not to backport it into 17 and also leave the other alone.

### Motivation and context

[JDK-8353013](https://bugs.openjdk.org/browse/JDK-8353013) addresses performance issue when parsing URIs like `https://98765432101.ddb.us-east-1.amazonaws.com/`. 

`URI.create` would first treat URIs starting with numbers as IPv4 addresses and throw exception as part of flow control if the formats don't match, then continue parsing. Exceptions as part of this flow control makes it expensive to parse DDB endpoints starting with account numbers due to expensive `Throwable.fillInStackTrace`.

Other details and benchmark results see https://bugs.openjdk.org/browse/JDK-8353013.


### How has this been tested?

`test/jdk/java/net/URI/Test.java` passed at local. GHA passed

JDK-8353013 is in mainline for ~4 weeks, no issue so far.


