### PR TITLE
8359435: AArch64: add support for SB instruction to MacroAssembler::spin_wait

### DIFF
--- a/src/hotspot/cpu/aarch64/assembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/assembler_aarch64.hpp
@@ -1060,6 +1060,10 @@ public:
     system(0b00, 0b011, 0b00011, SY, 0b110);
   }
 
+  void sb() {
+    system(0b00, 0b011, 0b00011, 0b0000, 0b111);
+  }
+
   void sys(int op1, int CRn, int CRm, int op2,
            Register rt = as_Register(0b11111)) {
     system(0b01, op1, CRn, CRm, op2, rt);

--- a/src/hotspot/cpu/aarch64/globals_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/globals_aarch64.hpp
@@ -117,7 +117,7 @@ define_pd_global(intx, InlineSmallCode,          1000);
   product(ccstr, OnSpinWaitInst, "none", DIAGNOSTIC,                    \
           "The instruction to use to implement "                        \
           "java.lang.Thread.onSpinWait()."                              \
-          "Options: none, nop, isb, yield.")                            \
+          "Options: none, nop, isb, yield, sb.")                        \
   product(uint, OnSpinWaitInstCount, 1, DIAGNOSTIC,                     \
           "The number of OnSpinWaitInst instructions to generate."      \
           "It cannot be used with OnSpinWaitInst=none.")                \

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -5724,6 +5724,9 @@ void MacroAssembler::spin_wait() {
       case SpinWait::YIELD:
         yield();
         break;
+      case SpinWait::SB:
+        sb();
+        break;
       default:
         ShouldNotReachHere();
     }

--- a/src/hotspot/cpu/aarch64/spin_wait_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/spin_wait_aarch64.hpp
@@ -31,7 +31,8 @@ public:
     NONE = -1,
     NOP,
     ISB,
-    YIELD
+    YIELD,
+    SB
   };
 
 private:

--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
@@ -56,8 +56,13 @@ static SpinWait get_spin_wait_desc() {
     return SpinWait(SpinWait::ISB, OnSpinWaitInstCount);
   } else if (strcmp(OnSpinWaitInst, "yield") == 0) {
     return SpinWait(SpinWait::YIELD, OnSpinWaitInstCount);
+  } else if (strcmp(OnSpinWaitInst, "sb") == 0) {
+    if ((VM_Version::features() & VM_Version::CPU_SB) == 0) {
+      vm_exit_during_initialization("OnSpinWaitInst is SB but current CPU does not support SB instruction");
+    }
+    return SpinWait(SpinWait::SB, OnSpinWaitInstCount);
   } else if (strcmp(OnSpinWaitInst, "none") != 0) {
-    vm_exit_during_initialization("The options for OnSpinWaitInst are nop, isb, yield, and none", OnSpinWaitInst);
+    vm_exit_during_initialization("The options for OnSpinWaitInst are nop, isb, yield, sb, and none", OnSpinWaitInst);
   }
 
   if (!FLAG_IS_DEFAULT(OnSpinWaitInstCount) && OnSpinWaitInstCount > 0) {

--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.hpp
@@ -126,6 +126,7 @@ public:
     decl(SHA3,          "sha3",          17)  \
     decl(SHA512,        "sha512",        21)  \
     decl(SVE,           "sve",           22)  \
+    decl(SB,            "sb",            29)  \
     /* flags above must follow Linux HWCAP */ \
     decl(SVE2,          "sve2",          28)  \
     decl(A53MAC,        "a53mac",        30)

--- a/src/hotspot/os_cpu/bsd_aarch64/vm_version_bsd_aarch64.cpp
+++ b/src/hotspot/os_cpu/bsd_aarch64/vm_version_bsd_aarch64.cpp
@@ -65,6 +65,10 @@ void VM_Version::get_os_cpu_info() {
   if (cpu_has("hw.optional.armv8_crc32"))     _features |= CPU_CRC32;
   if (cpu_has("hw.optional.armv8_1_atomics")) _features |= CPU_LSE;
 
+  if (cpu_has("hw.optional.arm.FEAT_SB")) {
+    _features |= CPU_SB;
+  }
+
   int cache_line_size;
   int hw_conf_cache_line[] = { CTL_HW, HW_CACHELINE };
   sysctllen = sizeof(cache_line_size);

--- a/src/hotspot/os_cpu/linux_aarch64/vm_version_linux_aarch64.cpp
+++ b/src/hotspot/os_cpu/linux_aarch64/vm_version_linux_aarch64.cpp
@@ -72,6 +72,10 @@
 #define HWCAP_SVE (1 << 22)
 #endif
 
+#ifndef HWCAP_SB
+#define HWCAP_SB (1 << 29)
+#endif
+
 #ifndef HWCAP2_SVE2
 #define HWCAP2_SVE2 (1 << 1)
 #endif
@@ -124,7 +128,8 @@ void VM_Version::get_os_cpu_info() {
       HWCAP_DCPOP   |
       HWCAP_SHA3    |
       HWCAP_SHA512  |
-      HWCAP_SVE);
+      HWCAP_SVE     |
+      HWCAP_SB);
 
   if (auxv2 & HWCAP2_SVE2) _features |= CPU_SVE2;
 

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/aarch64/AArch64.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/aarch64/AArch64.java
@@ -177,7 +177,7 @@ public class AArch64 extends Architecture {
         SHA3,
         SHA512,
         SVE,
-	SB,
+        SB,
         SVE2,
         A53MAC,
     }

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/aarch64/AArch64.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/aarch64/AArch64.java
@@ -177,6 +177,7 @@ public class AArch64 extends Architecture {
         SHA3,
         SHA512,
         SVE,
+	SB,
         SVE2,
         A53MAC,
     }

--- a/test/hotspot/gtest/aarch64/aarch64-asmtest.py
+++ b/test/hotspot/gtest/aarch64/aarch64-asmtest.py
@@ -1277,7 +1277,7 @@ generate (CondBranchOp, ["EQ", "NE", "HS", "CS", "LO", "CC", "MI", "PL", "VS", "
 generate (ImmOp, ["svc", "hvc", "smc", "brk", "hlt", # "dcps1",  "dcps2",  "dcps3"
                ])
 
-generate (Op, ["nop", "eret", "drps", "isb"])
+generate (Op, ["nop", "eret", "drps", "isb", "sb"])
 
 barriers = ["OSHLD", "OSHST", "OSH", "NSHLD", "NSHST", "NSH",
             "ISHLD", "ISHST", "ISH", "LD", "ST", "SY"]
@@ -1638,7 +1638,7 @@ outfile.write("forth:\n")
 outfile.close()
 
 # compile for sve with 8.2 and sha3 because of SHA3 crypto extension.
-subprocess.check_call([AARCH64_AS, "-march=armv8.2-a+sha3+sve", "aarch64ops.s", "-o", "aarch64ops.o"])
+subprocess.check_call([AARCH64_AS, "-march=armv8.2-a+sha3+sve+sb", "aarch64ops.s", "-o", "aarch64ops.o"])
 
 print
 print "/*"

--- a/test/hotspot/gtest/aarch64/asmtest.out.h
+++ b/test/hotspot/gtest/aarch64/asmtest.out.h
@@ -4,945 +4,946 @@
     __ bind(back);
 
 // ArithOp
-    __ add(r26, r23, r13, Assembler::LSL, 32);         //       add     x26, x23, x13, LSL #32
-    __ sub(r12, r24, r9, Assembler::LSR, 37);          //       sub     x12, x24, x9, LSR #37
-    __ adds(r28, r15, r8, Assembler::ASR, 39);         //       adds    x28, x15, x8, ASR #39
-    __ subs(r7, r28, r30, Assembler::ASR, 57);         //       subs    x7, x28, x30, ASR #57
-    __ addw(r9, r22, r27, Assembler::ASR, 15);         //       add     w9, w22, w27, ASR #15
-    __ subw(r3, r13, r17, Assembler::ASR, 30);         //       sub     w3, w13, w17, ASR #30
-    __ addsw(r14, r26, r8, Assembler::ASR, 17);        //       adds    w14, w26, w8, ASR #17
-    __ subsw(r0, r22, r12, Assembler::ASR, 21);        //       subs    w0, w22, w12, ASR #21
-    __ andr(r0, r15, r26, Assembler::LSL, 20);         //       and     x0, x15, x26, LSL #20
-    __ orr(r26, r5, r17, Assembler::LSL, 61);          //       orr     x26, x5, x17, LSL #61
-    __ eor(r24, r13, r2, Assembler::LSL, 32);          //       eor     x24, x13, x2, LSL #32
-    __ ands(r28, r3, r17, Assembler::ASR, 35);         //       ands    x28, x3, x17, ASR #35
-    __ andw(r25, r16, r29, Assembler::LSR, 18);        //       and     w25, w16, w29, LSR #18
-    __ orrw(r13, r17, r11, Assembler::LSR, 9);         //       orr     w13, w17, w11, LSR #9
-    __ eorw(r5, r5, r17, Assembler::LSR, 15);          //       eor     w5, w5, w17, LSR #15
-    __ andsw(r2, r23, r27, Assembler::ASR, 26);        //       ands    w2, w23, w27, ASR #26
-    __ bic(r27, r28, r16, Assembler::LSR, 45);         //       bic     x27, x28, x16, LSR #45
-    __ orn(r8, r25, r26, Assembler::ASR, 37);          //       orn     x8, x25, x26, ASR #37
-    __ eon(r29, r17, r13, Assembler::LSR, 63);         //       eon     x29, x17, x13, LSR #63
-    __ bics(r28, r24, r2, Assembler::LSR, 31);         //       bics    x28, x24, x2, LSR #31
-    __ bicw(r19, r26, r7, Assembler::ASR, 3);          //       bic     w19, w26, w7, ASR #3
-    __ ornw(r6, r24, r10, Assembler::ASR, 3);          //       orn     w6, w24, w10, ASR #3
-    __ eonw(r4, r21, r1, Assembler::LSR, 29);          //       eon     w4, w21, w1, LSR #29
-    __ bicsw(r16, r21, r0, Assembler::LSR, 19);        //       bics    w16, w21, w0, LSR #19
+    __ add(r27, r12, r24, Assembler::LSR, 5);          //	add	x27, x12, x24, LSR #5
+    __ sub(r8, r30, r16, Assembler::LSR, 51);          //	sub	x8, x30, x16, LSR #51
+    __ adds(r29, r25, r26, Assembler::LSR, 61);        //	adds	x29, x25, x26, LSR #61
+    __ subs(r11, r17, r28, Assembler::LSL, 17);        //	subs	x11, x17, x28, LSL #17
+    __ addw(r9, r4, r24, Assembler::LSL, 16);          //	add	w9, w4, w24, LSL #16
+    __ subw(r29, r17, r22, Assembler::ASR, 9);         //	sub	w29, w17, w22, ASR #9
+    __ addsw(r9, r3, r23, Assembler::LSL, 21);         //	adds	w9, w3, w23, LSL #21
+    __ subsw(r15, r17, r3, Assembler::LSR, 27);        //	subs	w15, w17, w3, LSR #27
+    __ andr(r10, r19, r20, Assembler::LSL, 61);        //	and	x10, x19, x20, LSL #61
+    __ orr(r14, r27, r16, Assembler::LSR, 7);          //	orr	x14, x27, x16, LSR #7
+    __ eor(r25, r29, r17, Assembler::LSL, 11);         //	eor	x25, x29, x17, LSL #11
+    __ ands(r23, r26, r12, Assembler::ASR, 0);         //	ands	x23, x26, x12, ASR #0
+    __ andw(r19, r15, r26, Assembler::LSR, 15);        //	and	w19, w15, w26, LSR #15
+    __ orrw(r23, r10, r22, Assembler::LSL, 12);        //	orr	w23, w10, w22, LSL #12
+    __ eorw(r29, r17, r7, Assembler::LSL, 9);          //	eor	w29, w17, w7, LSL #9
+    __ andsw(r25, r17, r14, Assembler::LSL, 5);        //	ands	w25, w17, w14, LSL #5
+    __ bic(r10, r28, r16, Assembler::LSR, 13);         //	bic	x10, x28, x16, LSR #13
+    __ orn(r9, r17, r9, Assembler::ASR, 15);           //	orn	x9, x17, x9, ASR #15
+    __ eon(r17, r10, r26, Assembler::ASR, 26);         //	eon	x17, x10, x26, ASR #26
+    __ bics(r30, r25, r19, Assembler::ASR, 36);        //	bics	x30, x25, x19, ASR #36
+    __ bicw(r14, r2, r19, Assembler::LSR, 20);         //	bic	w14, w2, w19, LSR #20
+    __ ornw(r17, r7, r9, Assembler::LSL, 12);          //	orn	w17, w7, w9, LSL #12
+    __ eonw(r26, r5, r1, Assembler::ASR, 16);          //	eon	w26, w5, w1, ASR #16
+    __ bicsw(r15, r2, r2, Assembler::ASR, 8);          //	bics	w15, w2, w2, ASR #8
 
 // AddSubImmOp
-    __ addw(r17, r12, 379u);                           //       add     w17, w12, #379
-    __ addsw(r30, r1, 22u);                            //       adds    w30, w1, #22
-    __ subw(r29, r5, 126u);                            //       sub     w29, w5, #126
-    __ subsw(r6, r24, 960u);                           //       subs    w6, w24, #960
-    __ add(r0, r13, 104u);                             //       add     x0, x13, #104
-    __ adds(r8, r6, 663u);                             //       adds    x8, x6, #663
-    __ sub(r10, r5, 516u);                             //       sub     x10, x5, #516
-    __ subs(r1, r3, 1012u);                            //       subs    x1, x3, #1012
+    __ addw(r28, r4, 79u);                             //	add	w28, w4, #79
+    __ addsw(r26, r2, 801u);                           //	adds	w26, w2, #801
+    __ subw(r26, r22, 564u);                           //	sub	w26, w22, #564
+    __ subsw(r16, r25, 482u);                          //	subs	w16, w25, #482
+    __ add(r27, r6, 858u);                             //	add	x27, x6, #858
+    __ adds(r17, r8, 922u);                            //	adds	x17, x8, #922
+    __ sub(r15, r21, 731u);                            //	sub	x15, x21, #731
+    __ subs(r2, r10, 236u);                            //	subs	x2, x10, #236
 
 // LogicalImmOp
-    __ andw(r6, r11, 4294049777ull);                   //       and     w6, w11, #0xfff1fff1
-    __ orrw(r28, r5, 4294966791ull);                   //       orr     w28, w5, #0xfffffe07
-    __ eorw(r1, r20, 134217216ull);                    //       eor     w1, w20, #0x7fffe00
-    __ andsw(r7, r17, 1048576ull);                     //       ands    w7, w17, #0x100000
-    __ andr(r14, r12, 9223372036854775808ull);         //       and     x14, x12, #0x8000000000000000
-    __ orr(r9, r11, 562675075514368ull);               //       orr     x9, x11, #0x1ffc000000000
-    __ eor(r17, r0, 18014398509481728ull);             //       eor     x17, x0, #0x3fffffffffff00
-    __ ands(r1, r8, 18446744073705357315ull);          //       ands    x1, x8, #0xffffffffffc00003
+    __ andw(r15, r17, 268427264ull);                   //	and	w15, w17, #0xfffe000
+    __ orrw(r7, r0, 7864320ull);                       //	orr	w7, w0, #0x780000
+    __ eorw(r22, r7, 130023424ull);                    //	eor	w22, w7, #0x7c00000
+    __ andsw(r10, r13, 2097120ull);                    //	ands	w10, w13, #0x1fffe0
+    __ andr(r25, r4, 536608768ull);                    //	and	x25, x4, #0x1ffc0000
+    __ orr(r26, r17, 4194300ull);                      //	orr	x26, x17, #0x3ffffc
+    __ eor(r3, r20, 211106232532992ull);               //	eor	x3, x20, #0xc00000000000
+    __ ands(r12, r2, 70368743653376ull);               //	ands	x12, x2, #0x3ffffff80000
 
 // AbsOp
-    __ b(__ pc());                                     //       b       .
-    __ b(back);                                        //       b       back
-    __ b(forth);                                       //       b       forth
-    __ bl(__ pc());                                    //       bl      .
-    __ bl(back);                                       //       bl      back
-    __ bl(forth);                                      //       bl      forth
+    __ b(__ pc());                                     //	b	.
+    __ b(back);                                        //	b	back
+    __ b(forth);                                       //	b	forth
+    __ bl(__ pc());                                    //	bl	.
+    __ bl(back);                                       //	bl	back
+    __ bl(forth);                                      //	bl	forth
 
 // RegAndAbsOp
-    __ cbzw(r10, __ pc());                             //       cbz     w10, .
-    __ cbzw(r10, back);                                //       cbz     w10, back
-    __ cbzw(r10, forth);                               //       cbz     w10, forth
-    __ cbnzw(r8, __ pc());                             //       cbnz    w8, .
-    __ cbnzw(r8, back);                                //       cbnz    w8, back
-    __ cbnzw(r8, forth);                               //       cbnz    w8, forth
-    __ cbz(r11, __ pc());                              //       cbz     x11, .
-    __ cbz(r11, back);                                 //       cbz     x11, back
-    __ cbz(r11, forth);                                //       cbz     x11, forth
-    __ cbnz(r29, __ pc());                             //       cbnz    x29, .
-    __ cbnz(r29, back);                                //       cbnz    x29, back
-    __ cbnz(r29, forth);                               //       cbnz    x29, forth
-    __ adr(r19, __ pc());                              //       adr     x19, .
-    __ adr(r19, back);                                 //       adr     x19, back
-    __ adr(r19, forth);                                //       adr     x19, forth
-    __ _adrp(r19, __ pc());                            //       adrp    x19, .
+    __ cbzw(r1, __ pc());                              //	cbz	w1, .
+    __ cbzw(r1, back);                                 //	cbz	w1, back
+    __ cbzw(r1, forth);                                //	cbz	w1, forth
+    __ cbnzw(r19, __ pc());                            //	cbnz	w19, .
+    __ cbnzw(r19, back);                               //	cbnz	w19, back
+    __ cbnzw(r19, forth);                              //	cbnz	w19, forth
+    __ cbz(r0, __ pc());                               //	cbz	x0, .
+    __ cbz(r0, back);                                  //	cbz	x0, back
+    __ cbz(r0, forth);                                 //	cbz	x0, forth
+    __ cbnz(r6, __ pc());                              //	cbnz	x6, .
+    __ cbnz(r6, back);                                 //	cbnz	x6, back
+    __ cbnz(r6, forth);                                //	cbnz	x6, forth
+    __ adr(r30, __ pc());                              //	adr	x30, .
+    __ adr(r30, back);                                 //	adr	x30, back
+    __ adr(r30, forth);                                //	adr	x30, forth
+    __ _adrp(r5, __ pc());                             //	adrp	x5, .
 
 // RegImmAbsOp
-    __ tbz(r22, 6, __ pc());                           //       tbz     x22, #6, .
-    __ tbz(r22, 6, back);                              //       tbz     x22, #6, back
-    __ tbz(r22, 6, forth);                             //       tbz     x22, #6, forth
-    __ tbnz(r12, 11, __ pc());                         //       tbnz    x12, #11, .
-    __ tbnz(r12, 11, back);                            //       tbnz    x12, #11, back
-    __ tbnz(r12, 11, forth);                           //       tbnz    x12, #11, forth
+    __ tbz(r22, 3, __ pc());                           //	tbz	x22, #3, .
+    __ tbz(r22, 3, back);                              //	tbz	x22, #3, back
+    __ tbz(r22, 3, forth);                             //	tbz	x22, #3, forth
+    __ tbnz(r15, 6, __ pc());                          //	tbnz	x15, #6, .
+    __ tbnz(r15, 6, back);                             //	tbnz	x15, #6, back
+    __ tbnz(r15, 6, forth);                            //	tbnz	x15, #6, forth
 
 // MoveWideImmOp
-    __ movnw(r0, 6301, 0);                             //       movn    w0, #6301, lsl 0
-    __ movzw(r7, 20886, 0);                            //       movz    w7, #20886, lsl 0
-    __ movkw(r27, 18617, 0);                           //       movk    w27, #18617, lsl 0
-    __ movn(r12, 22998, 16);                           //       movn    x12, #22998, lsl 16
-    __ movz(r20, 1532, 16);                            //       movz    x20, #1532, lsl 16
-    __ movk(r8, 5167, 32);                             //       movk    x8, #5167, lsl 32
+    __ movnw(r23, 4003, 0);                            //	movn	w23, #4003, lsl 0
+    __ movzw(r17, 27893, 0);                           //	movz	w17, #27893, lsl 0
+    __ movkw(r26, 17034, 0);                           //	movk	w26, #17034, lsl 0
+    __ movn(r7, 4716, 32);                             //	movn	x7, #4716, lsl 32
+    __ movz(r11, 28578, 16);                           //	movz	x11, #28578, lsl 16
+    __ movk(r1, 30613, 0);                             //	movk	x1, #30613, lsl 0
 
 // BitfieldOp
-    __ sbfm(r15, r17, 24, 28);                         //       sbfm    x15, x17, #24, #28
-    __ bfmw(r15, r9, 14, 25);                          //       bfm     w15, w9, #14, #25
-    __ ubfmw(r27, r25, 6, 31);                         //       ubfm    w27, w25, #6, #31
-    __ sbfm(r19, r2, 23, 31);                          //       sbfm    x19, x2, #23, #31
-    __ bfm(r12, r21, 10, 6);                           //       bfm     x12, x21, #10, #6
-    __ ubfm(r22, r0, 26, 16);                          //       ubfm    x22, x0, #26, #16
+    __ sbfm(r19, r3, 25, 12);                          //	sbfm	x19, x3, #25, #12
+    __ bfmw(r8, r11, 30, 10);                          //	bfm	w8, w11, #30, #10
+    __ ubfmw(r22, r21, 13, 3);                         //	ubfm	w22, w21, #13, #3
+    __ sbfm(r25, r21, 10, 10);                         //	sbfm	x25, x21, #10, #10
+    __ bfm(r10, r16, 16, 7);                           //	bfm	x10, x16, #16, #7
+    __ ubfm(r19, r29, 28, 11);                         //	ubfm	x19, x29, #28, #11
 
 // ExtractOp
-    __ extrw(r3, r3, r20, 27);                         //       extr    w3, w3, w20, #27
-    __ extr(r8, r30, r3, 54);                          //       extr    x8, x30, x3, #54
+    __ extrw(r0, r15, r21, 26);                        //	extr	w0, w15, w21, #26
+    __ extr(r28, r17, r27, 39);                        //	extr	x28, x17, x27, #39
 
 // CondBranchOp
-    __ br(Assembler::EQ, __ pc());                     //       b.EQ    .
-    __ br(Assembler::EQ, back);                        //       b.EQ    back
-    __ br(Assembler::EQ, forth);                       //       b.EQ    forth
-    __ br(Assembler::NE, __ pc());                     //       b.NE    .
-    __ br(Assembler::NE, back);                        //       b.NE    back
-    __ br(Assembler::NE, forth);                       //       b.NE    forth
-    __ br(Assembler::HS, __ pc());                     //       b.HS    .
-    __ br(Assembler::HS, back);                        //       b.HS    back
-    __ br(Assembler::HS, forth);                       //       b.HS    forth
-    __ br(Assembler::CS, __ pc());                     //       b.CS    .
-    __ br(Assembler::CS, back);                        //       b.CS    back
-    __ br(Assembler::CS, forth);                       //       b.CS    forth
-    __ br(Assembler::LO, __ pc());                     //       b.LO    .
-    __ br(Assembler::LO, back);                        //       b.LO    back
-    __ br(Assembler::LO, forth);                       //       b.LO    forth
-    __ br(Assembler::CC, __ pc());                     //       b.CC    .
-    __ br(Assembler::CC, back);                        //       b.CC    back
-    __ br(Assembler::CC, forth);                       //       b.CC    forth
-    __ br(Assembler::MI, __ pc());                     //       b.MI    .
-    __ br(Assembler::MI, back);                        //       b.MI    back
-    __ br(Assembler::MI, forth);                       //       b.MI    forth
-    __ br(Assembler::PL, __ pc());                     //       b.PL    .
-    __ br(Assembler::PL, back);                        //       b.PL    back
-    __ br(Assembler::PL, forth);                       //       b.PL    forth
-    __ br(Assembler::VS, __ pc());                     //       b.VS    .
-    __ br(Assembler::VS, back);                        //       b.VS    back
-    __ br(Assembler::VS, forth);                       //       b.VS    forth
-    __ br(Assembler::VC, __ pc());                     //       b.VC    .
-    __ br(Assembler::VC, back);                        //       b.VC    back
-    __ br(Assembler::VC, forth);                       //       b.VC    forth
-    __ br(Assembler::HI, __ pc());                     //       b.HI    .
-    __ br(Assembler::HI, back);                        //       b.HI    back
-    __ br(Assembler::HI, forth);                       //       b.HI    forth
-    __ br(Assembler::LS, __ pc());                     //       b.LS    .
-    __ br(Assembler::LS, back);                        //       b.LS    back
-    __ br(Assembler::LS, forth);                       //       b.LS    forth
-    __ br(Assembler::GE, __ pc());                     //       b.GE    .
-    __ br(Assembler::GE, back);                        //       b.GE    back
-    __ br(Assembler::GE, forth);                       //       b.GE    forth
-    __ br(Assembler::LT, __ pc());                     //       b.LT    .
-    __ br(Assembler::LT, back);                        //       b.LT    back
-    __ br(Assembler::LT, forth);                       //       b.LT    forth
-    __ br(Assembler::GT, __ pc());                     //       b.GT    .
-    __ br(Assembler::GT, back);                        //       b.GT    back
-    __ br(Assembler::GT, forth);                       //       b.GT    forth
-    __ br(Assembler::LE, __ pc());                     //       b.LE    .
-    __ br(Assembler::LE, back);                        //       b.LE    back
-    __ br(Assembler::LE, forth);                       //       b.LE    forth
-    __ br(Assembler::AL, __ pc());                     //       b.AL    .
-    __ br(Assembler::AL, back);                        //       b.AL    back
-    __ br(Assembler::AL, forth);                       //       b.AL    forth
-    __ br(Assembler::NV, __ pc());                     //       b.NV    .
-    __ br(Assembler::NV, back);                        //       b.NV    back
-    __ br(Assembler::NV, forth);                       //       b.NV    forth
+    __ br(Assembler::EQ, __ pc());                     //	b.EQ	.
+    __ br(Assembler::EQ, back);                        //	b.EQ	back
+    __ br(Assembler::EQ, forth);                       //	b.EQ	forth
+    __ br(Assembler::NE, __ pc());                     //	b.NE	.
+    __ br(Assembler::NE, back);                        //	b.NE	back
+    __ br(Assembler::NE, forth);                       //	b.NE	forth
+    __ br(Assembler::HS, __ pc());                     //	b.HS	.
+    __ br(Assembler::HS, back);                        //	b.HS	back
+    __ br(Assembler::HS, forth);                       //	b.HS	forth
+    __ br(Assembler::CS, __ pc());                     //	b.CS	.
+    __ br(Assembler::CS, back);                        //	b.CS	back
+    __ br(Assembler::CS, forth);                       //	b.CS	forth
+    __ br(Assembler::LO, __ pc());                     //	b.LO	.
+    __ br(Assembler::LO, back);                        //	b.LO	back
+    __ br(Assembler::LO, forth);                       //	b.LO	forth
+    __ br(Assembler::CC, __ pc());                     //	b.CC	.
+    __ br(Assembler::CC, back);                        //	b.CC	back
+    __ br(Assembler::CC, forth);                       //	b.CC	forth
+    __ br(Assembler::MI, __ pc());                     //	b.MI	.
+    __ br(Assembler::MI, back);                        //	b.MI	back
+    __ br(Assembler::MI, forth);                       //	b.MI	forth
+    __ br(Assembler::PL, __ pc());                     //	b.PL	.
+    __ br(Assembler::PL, back);                        //	b.PL	back
+    __ br(Assembler::PL, forth);                       //	b.PL	forth
+    __ br(Assembler::VS, __ pc());                     //	b.VS	.
+    __ br(Assembler::VS, back);                        //	b.VS	back
+    __ br(Assembler::VS, forth);                       //	b.VS	forth
+    __ br(Assembler::VC, __ pc());                     //	b.VC	.
+    __ br(Assembler::VC, back);                        //	b.VC	back
+    __ br(Assembler::VC, forth);                       //	b.VC	forth
+    __ br(Assembler::HI, __ pc());                     //	b.HI	.
+    __ br(Assembler::HI, back);                        //	b.HI	back
+    __ br(Assembler::HI, forth);                       //	b.HI	forth
+    __ br(Assembler::LS, __ pc());                     //	b.LS	.
+    __ br(Assembler::LS, back);                        //	b.LS	back
+    __ br(Assembler::LS, forth);                       //	b.LS	forth
+    __ br(Assembler::GE, __ pc());                     //	b.GE	.
+    __ br(Assembler::GE, back);                        //	b.GE	back
+    __ br(Assembler::GE, forth);                       //	b.GE	forth
+    __ br(Assembler::LT, __ pc());                     //	b.LT	.
+    __ br(Assembler::LT, back);                        //	b.LT	back
+    __ br(Assembler::LT, forth);                       //	b.LT	forth
+    __ br(Assembler::GT, __ pc());                     //	b.GT	.
+    __ br(Assembler::GT, back);                        //	b.GT	back
+    __ br(Assembler::GT, forth);                       //	b.GT	forth
+    __ br(Assembler::LE, __ pc());                     //	b.LE	.
+    __ br(Assembler::LE, back);                        //	b.LE	back
+    __ br(Assembler::LE, forth);                       //	b.LE	forth
+    __ br(Assembler::AL, __ pc());                     //	b.AL	.
+    __ br(Assembler::AL, back);                        //	b.AL	back
+    __ br(Assembler::AL, forth);                       //	b.AL	forth
+    __ br(Assembler::NV, __ pc());                     //	b.NV	.
+    __ br(Assembler::NV, back);                        //	b.NV	back
+    __ br(Assembler::NV, forth);                       //	b.NV	forth
 
 // ImmOp
-    __ svc(12999);                                     //       svc     #12999
-    __ hvc(2665);                                      //       hvc     #2665
-    __ smc(9002);                                      //       smc     #9002
-    __ brk(14843);                                     //       brk     #14843
-    __ hlt(25964);                                     //       hlt     #25964
+    __ svc(23406);                                     //	svc	#23406
+    __ hvc(25470);                                     //	hvc	#25470
+    __ smc(16445);                                     //	smc	#16445
+    __ brk(10054);                                     //	brk	#10054
+    __ hlt(815);                                       //	hlt	#815
 
 // Op
-    __ nop();                                          //       nop
-    __ eret();                                         //       eret
-    __ drps();                                         //       drps
-    __ isb();                                          //       isb
+    __ nop();                                          //	nop
+    __ eret();                                         //	eret
+    __ drps();                                         //	drps
+    __ isb();                                          //	isb
+    __ sb();                                           //	sb
 
 // SystemOp
-    __ dsb(Assembler::ST);                             //       dsb     ST
-    __ dmb(Assembler::OSHST);                          //       dmb     OSHST
+    __ dsb(Assembler::ISHST);                          //	dsb	ISHST
+    __ dmb(Assembler::SY);                             //	dmb	SY
 
 // OneRegOp
-    __ br(r16);                                        //       br      x16
-    __ blr(r20);                                       //       blr     x20
+    __ br(r2);                                         //	br	x2
+    __ blr(r10);                                       //	blr	x10
 
 // LoadStoreExclusiveOp
-    __ stxr(r10, r27, r8);                             //       stxr    w10, x27, [x8]
-    __ stlxr(r0, r1, r21);                             //       stlxr   w0, x1, [x21]
-    __ ldxr(r17, r29);                                 //       ldxr    x17, [x29]
-    __ ldaxr(r29, r28);                                //       ldaxr   x29, [x28]
-    __ stlr(r1, r23);                                  //       stlr    x1, [x23]
-    __ ldar(r21, r20);                                 //       ldar    x21, [x20]
+    __ stxr(r23, r1, r17);                             //	stxr	w23, x1, [x17]
+    __ stlxr(r8, r4, r7);                              //	stlxr	w8, x4, [x7]
+    __ ldxr(r24, r30);                                 //	ldxr	x24, [x30]
+    __ ldaxr(r15, r11);                                //	ldaxr	x15, [x11]
+    __ stlr(r19, r9);                                  //	stlr	x19, [x9]
+    __ ldar(r21, r11);                                 //	ldar	x21, [x11]
 
 // LoadStoreExclusiveOp
-    __ stxrw(r22, r27, r19);                           //       stxr    w22, w27, [x19]
-    __ stlxrw(r11, r16, r6);                           //       stlxr   w11, w16, [x6]
-    __ ldxrw(r17, r0);                                 //       ldxr    w17, [x0]
-    __ ldaxrw(r4, r10);                                //       ldaxr   w4, [x10]
-    __ stlrw(r24, r22);                                //       stlr    w24, [x22]
-    __ ldarw(r10, r19);                                //       ldar    w10, [x19]
+    __ stxrw(r17, r30, r28);                           //	stxr	w17, w30, [x28]
+    __ stlxrw(r20, r27, r19);                          //	stlxr	w20, w27, [x19]
+    __ ldxrw(r4, r22);                                 //	ldxr	w4, [x22]
+    __ ldaxrw(r9, r12);                                //	ldaxr	w9, [x12]
+    __ stlrw(r23, r13);                                //	stlr	w23, [x13]
+    __ ldarw(r26, r20);                                //	ldar	w26, [x20]
 
 // LoadStoreExclusiveOp
-    __ stxrh(r1, r5, r30);                             //       stxrh   w1, w5, [x30]
-    __ stlxrh(r8, r12, r17);                           //       stlxrh  w8, w12, [x17]
-    __ ldxrh(r9, r14);                                 //       ldxrh   w9, [x14]
-    __ ldaxrh(r7, r1);                                 //       ldaxrh  w7, [x1]
-    __ stlrh(r5, r16);                                 //       stlrh   w5, [x16]
-    __ ldarh(r2, r12);                                 //       ldarh   w2, [x12]
+    __ stxrh(r2, r0, r19);                             //	stxrh	w2, w0, [x19]
+    __ stlxrh(r6, r22, r10);                           //	stlxrh	w6, w22, [x10]
+    __ ldxrh(r5, r7);                                  //	ldxrh	w5, [x7]
+    __ ldaxrh(r7, r20);                                //	ldaxrh	w7, [x20]
+    __ stlrh(r14, r12);                                //	stlrh	w14, [x12]
+    __ ldarh(r22, r28);                                //	ldarh	w22, [x28]
 
 // LoadStoreExclusiveOp
-    __ stxrb(r10, r12, r3);                            //       stxrb   w10, w12, [x3]
-    __ stlxrb(r28, r14, r26);                          //       stlxrb  w28, w14, [x26]
-    __ ldxrb(r30, r10);                                //       ldxrb   w30, [x10]
-    __ ldaxrb(r14, r21);                               //       ldaxrb  w14, [x21]
-    __ stlrb(r13, r9);                                 //       stlrb   w13, [x9]
-    __ ldarb(r22, r27);                                //       ldarb   w22, [x27]
+    __ stxrb(r21, r17, r27);                           //	stxrb	w21, w17, [x27]
+    __ stlxrb(r13, r1, r12);                           //	stlxrb	w13, w1, [x12]
+    __ ldxrb(r27, r22);                                //	ldxrb	w27, [x22]
+    __ ldaxrb(r17, r13);                               //	ldaxrb	w17, [x13]
+    __ stlrb(r24, r21);                                //	stlrb	w24, [x21]
+    __ ldarb(r22, r1);                                 //	ldarb	w22, [x1]
 
 // LoadStoreExclusiveOp
-    __ ldxp(r28, r19, r11);                            //       ldxp    x28, x19, [x11]
-    __ ldaxp(r30, r19, r2);                            //       ldaxp   x30, x19, [x2]
-    __ stxp(r2, r23, r1, r0);                          //       stxp    w2, x23, x1, [x0]
-    __ stlxp(r12, r16, r13, r15);                      //       stlxp   w12, x16, x13, [x15]
+    __ ldxp(r5, r14, r2);                              //	ldxp	x5, x14, [x2]
+    __ ldaxp(r8, r22, r5);                             //	ldaxp	x8, x22, [x5]
+    __ stxp(r14, r16, r28, r15);                       //	stxp	w14, x16, x28, [x15]
+    __ stlxp(r29, r17, r19, r24);                      //	stlxp	w29, x17, x19, [x24]
 
 // LoadStoreExclusiveOp
-    __ ldxpw(r17, r21, r13);                           //       ldxp    w17, w21, [x13]
-    __ ldaxpw(r11, r30, r8);                           //       ldaxp   w11, w30, [x8]
-    __ stxpw(r24, r13, r11, r1);                       //       stxp    w24, w13, w11, [x1]
-    __ stlxpw(r26, r21, r27, r13);                     //       stlxp   w26, w21, w27, [x13]
+    __ ldxpw(r0, r28, r1);                             //	ldxp	w0, w28, [x1]
+    __ ldaxpw(r15, r10, r9);                           //	ldaxp	w15, w10, [x9]
+    __ stxpw(r26, r14, r1, r25);                       //	stxp	w26, w14, w1, [x25]
+    __ stlxpw(r26, r28, r25, r13);                     //	stlxp	w26, w28, w25, [x13]
 
 // base_plus_unscaled_offset
 // LoadStoreOp
-    __ str(r11, Address(r20, -103));                   //       str     x11, [x20, -103]
-    __ strw(r28, Address(r16, 62));                    //       str     w28, [x16, 62]
-    __ strb(r27, Address(r9, -9));                     //       strb    w27, [x9, -9]
-    __ strh(r2, Address(r25, -50));                    //       strh    w2, [x25, -50]
-    __ ldr(r4, Address(r2, -241));                     //       ldr     x4, [x2, -241]
-    __ ldrw(r30, Address(r20, -31));                   //       ldr     w30, [x20, -31]
-    __ ldrb(r17, Address(r23, -23));                   //       ldrb    w17, [x23, -23]
-    __ ldrh(r29, Address(r26, -1));                    //       ldrh    w29, [x26, -1]
-    __ ldrsb(r1, Address(r9, 6));                      //       ldrsb   x1, [x9, 6]
-    __ ldrsh(r11, Address(r12, 19));                   //       ldrsh   x11, [x12, 19]
-    __ ldrshw(r11, Address(r1, -50));                  //       ldrsh   w11, [x1, -50]
-    __ ldrsw(r19, Address(r24, 41));                   //       ldrsw   x19, [x24, 41]
-    __ ldrd(v24, Address(r24, 95));                    //       ldr     d24, [x24, 95]
-    __ ldrs(v15, Address(r5, -43));                    //       ldr     s15, [x5, -43]
-    __ strd(v21, Address(r27, 1));                     //       str     d21, [x27, 1]
-    __ strs(v23, Address(r13, -107));                  //       str     s23, [x13, -107]
+    __ str(r10, Address(r6, 69));                      //	str	x10, [x6, 69]
+    __ strw(r19, Address(r0, -125));                   //	str	w19, [x0, -125]
+    __ strb(r20, Address(r20, -13));                   //	strb	w20, [x20, -13]
+    __ strh(r27, Address(r2, -29));                    //	strh	w27, [x2, -29]
+    __ ldr(r30, Address(r4, -247));                    //	ldr	x30, [x4, -247]
+    __ ldrw(r11, Address(r17, -118));                  //	ldr	w11, [x17, -118]
+    __ ldrb(r4, Address(r27, -21));                    //	ldrb	w4, [x27, -21]
+    __ ldrh(r8, Address(r8, -21));                     //	ldrh	w8, [x8, -21]
+    __ ldrsb(r15, Address(r5, 5));                     //	ldrsb	x15, [x5, 5]
+    __ ldrsh(r26, Address(r23, -58));                  //	ldrsh	x26, [x23, -58]
+    __ ldrshw(r26, Address(r10, -11));                 //	ldrsh	w26, [x10, -11]
+    __ ldrsw(r9, Address(r25, -41));                   //	ldrsw	x9, [x25, -41]
+    __ ldrd(v25, Address(r10, 95));                    //	ldr	d25, [x10, 95]
+    __ ldrs(v17, Address(r2, 63));                     //	ldr	s17, [x2, 63]
+    __ strd(v11, Address(r16, -27));                   //	str	d11, [x16, -27]
+    __ strs(v26, Address(r7, 21));                     //	str	s26, [x7, 21]
 
 // pre
 // LoadStoreOp
-    __ str(r10, Address(__ pre(r0, 8)));               //       str     x10, [x0, 8]!
-    __ strw(r3, Address(__ pre(r0, 29)));              //       str     w3, [x0, 29]!
-    __ strb(r10, Address(__ pre(r14, 9)));             //       strb    w10, [x14, 9]!
-    __ strh(r29, Address(__ pre(r25, -3)));            //       strh    w29, [x25, -3]!
-    __ ldr(r12, Address(__ pre(r16, -144)));           //       ldr     x12, [x16, -144]!
-    __ ldrw(r12, Address(__ pre(r22, -6)));            //       ldr     w12, [x22, -6]!
-    __ ldrb(r13, Address(__ pre(r11, -10)));           //       ldrb    w13, [x11, -10]!
-    __ ldrh(r0, Address(__ pre(r21, -21)));            //       ldrh    w0, [x21, -21]!
-    __ ldrsb(r23, Address(__ pre(r6, 4)));             //       ldrsb   x23, [x6, 4]!
-    __ ldrsh(r3, Address(__ pre(r7, -53)));            //       ldrsh   x3, [x7, -53]!
-    __ ldrshw(r28, Address(__ pre(r4, -7)));           //       ldrsh   w28, [x4, -7]!
-    __ ldrsw(r24, Address(__ pre(r8, -18)));           //       ldrsw   x24, [x8, -18]!
-    __ ldrd(v14, Address(__ pre(r11, 12)));            //       ldr     d14, [x11, 12]!
-    __ ldrs(v19, Address(__ pre(r12, -67)));           //       ldr     s19, [x12, -67]!
-    __ strd(v20, Address(__ pre(r0, -253)));           //       str     d20, [x0, -253]!
-    __ strs(v8, Address(__ pre(r0, 64)));              //       str     s8, [x0, 64]!
+    __ str(r8, Address(__ pre(r6, -242)));             //	str	x8, [x6, -242]!
+    __ strw(r17, Address(__ pre(r27, 31)));            //	str	w17, [x27, 31]!
+    __ strb(r30, Address(__ pre(r29, -1)));            //	strb	w30, [x29, -1]!
+    __ strh(r23, Address(__ pre(r24, -1)));            //	strh	w23, [x24, -1]!
+    __ ldr(r9, Address(__ pre(r23, -238)));            //	ldr	x9, [x23, -238]!
+    __ ldrw(r1, Address(__ pre(r9, -112)));            //	ldr	w1, [x9, -112]!
+    __ ldrb(r16, Address(__ pre(r1, -11)));            //	ldrb	w16, [x1, -11]!
+    __ ldrh(r29, Address(__ pre(r20, 2)));             //	ldrh	w29, [x20, 2]!
+    __ ldrsb(r5, Address(__ pre(r9, -8)));             //	ldrsb	x5, [x9, -8]!
+    __ ldrsh(r26, Address(__ pre(r12, -22)));          //	ldrsh	x26, [x12, -22]!
+    __ ldrshw(r13, Address(__ pre(r4, -48)));          //	ldrsh	w13, [x4, -48]!
+    __ ldrsw(r20, Address(__ pre(r14, 55)));           //	ldrsw	x20, [x14, 55]!
+    __ ldrd(v20, Address(__ pre(r12, -205)));          //	ldr	d20, [x12, -205]!
+    __ ldrs(v3, Address(__ pre(r10, 12)));             //	ldr	s3, [x10, 12]!
+    __ strd(v25, Address(__ pre(r28, 102)));           //	str	d25, [x28, 102]!
+    __ strs(v25, Address(__ pre(r27, -53)));           //	str	s25, [x27, -53]!
 
 // post
 // LoadStoreOp
-    __ str(r3, Address(__ post(r28, -94)));            //       str     x3, [x28], -94
-    __ strw(r11, Address(__ post(r7, -54)));           //       str     w11, [x7], -54
-    __ strb(r27, Address(__ post(r10, -24)));          //       strb    w27, [x10], -24
-    __ strh(r6, Address(__ post(r7, 27)));             //       strh    w6, [x7], 27
-    __ ldr(r13, Address(__ post(r10, -202)));          //       ldr     x13, [x10], -202
-    __ ldrw(r15, Address(__ post(r5, -41)));           //       ldr     w15, [x5], -41
-    __ ldrb(r2, Address(__ post(r13, 9)));             //       ldrb    w2, [x13], 9
-    __ ldrh(r28, Address(__ post(r13, -20)));          //       ldrh    w28, [x13], -20
-    __ ldrsb(r9, Address(__ post(r13, -31)));          //       ldrsb   x9, [x13], -31
-    __ ldrsh(r3, Address(__ post(r24, -36)));          //       ldrsh   x3, [x24], -36
-    __ ldrshw(r20, Address(__ post(r3, 6)));           //       ldrsh   w20, [x3], 6
-    __ ldrsw(r7, Address(__ post(r19, -1)));           //       ldrsw   x7, [x19], -1
-    __ ldrd(v30, Address(__ post(r8, -130)));          //       ldr     d30, [x8], -130
-    __ ldrs(v25, Address(__ post(r15, 21)));           //       ldr     s25, [x15], 21
-    __ strd(v14, Address(__ post(r23, 90)));           //       str     d14, [x23], 90
-    __ strs(v8, Address(__ post(r0, -33)));            //       str     s8, [x0], -33
+    __ str(r8, Address(__ post(r29, -23)));            //	str	x8, [x29], -23
+    __ strw(r27, Address(__ post(r29, 17)));           //	str	w27, [x29], 17
+    __ strb(r29, Address(__ post(r19, 1)));            //	strb	w29, [x19], 1
+    __ strh(r0, Address(__ post(r26, -11)));           //	strh	w0, [x26], -11
+    __ ldr(r2, Address(__ post(r3, -241)));            //	ldr	x2, [x3], -241
+    __ ldrw(r20, Address(__ post(r29, -39)));          //	ldr	w20, [x29], -39
+    __ ldrb(r23, Address(__ post(r0, 10)));            //	ldrb	w23, [x0], 10
+    __ ldrh(r8, Address(__ post(r4, -41)));            //	ldrh	w8, [x4], -41
+    __ ldrsb(r19, Address(__ post(r2, -11)));          //	ldrsb	x19, [x2], -11
+    __ ldrsh(r16, Address(__ post(r7, -44)));          //	ldrsh	x16, [x7], -44
+    __ ldrshw(r2, Address(__ post(r23, -17)));         //	ldrsh	w2, [x23], -17
+    __ ldrsw(r11, Address(__ post(r2, 12)));           //	ldrsw	x11, [x2], 12
+    __ ldrd(v0, Address(__ post(r7, 70)));             //	ldr	d0, [x7], 70
+    __ ldrs(v2, Address(__ post(r13, -16)));           //	ldr	s2, [x13], -16
+    __ strd(v5, Address(__ post(r30, -199)));          //	str	d5, [x30], -199
+    __ strs(v14, Address(__ post(r24, -65)));          //	str	s14, [x24], -65
 
 // base_plus_reg
 // LoadStoreOp
-    __ str(r10, Address(r17, r21, Address::sxtw(3)));  //       str     x10, [x17, w21, sxtw #3]
-    __ strw(r4, Address(r13, r22, Address::sxtw(2)));  //       str     w4, [x13, w22, sxtw #2]
-    __ strb(r13, Address(r0, r19, Address::uxtw(0)));  //       strb    w13, [x0, w19, uxtw #0]
-    __ strh(r12, Address(r27, r6, Address::sxtw(0)));  //       strh    w12, [x27, w6, sxtw #0]
-    __ ldr(r0, Address(r8, r16, Address::lsl(0)));     //       ldr     x0, [x8, x16, lsl #0]
-    __ ldrw(r0, Address(r4, r26, Address::sxtx(0)));   //       ldr     w0, [x4, x26, sxtx #0]
-    __ ldrb(r14, Address(r25, r5, Address::sxtw(0)));  //       ldrb    w14, [x25, w5, sxtw #0]
-    __ ldrh(r9, Address(r4, r17, Address::uxtw(0)));   //       ldrh    w9, [x4, w17, uxtw #0]
-    __ ldrsb(r27, Address(r4, r7, Address::lsl(0)));   //       ldrsb   x27, [x4, x7, lsl #0]
-    __ ldrsh(r15, Address(r17, r30, Address::sxtw(0))); //      ldrsh   x15, [x17, w30, sxtw #0]
-    __ ldrshw(r16, Address(r0, r22, Address::sxtw(0))); //      ldrsh   w16, [x0, w22, sxtw #0]
-    __ ldrsw(r22, Address(r10, r30, Address::sxtx(2))); //      ldrsw   x22, [x10, x30, sxtx #2]
-    __ ldrd(v29, Address(r21, r10, Address::sxtx(3))); //       ldr     d29, [x21, x10, sxtx #3]
-    __ ldrs(v3, Address(r11, r19, Address::uxtw(0)));  //       ldr     s3, [x11, w19, uxtw #0]
-    __ strd(v13, Address(r28, r29, Address::uxtw(3))); //       str     d13, [x28, w29, uxtw #3]
-    __ strs(v23, Address(r29, r5, Address::sxtx(2)));  //       str     s23, [x29, x5, sxtx #2]
+    __ str(r0, Address(r20, r20, Address::sxtx(3)));   //	str	x0, [x20, x20, sxtx #3]
+    __ strw(r2, Address(r6, r9, Address::sxtx(2)));    //	str	w2, [x6, x9, sxtx #2]
+    __ strb(r28, Address(r21, r15, Address::uxtw(0))); //	strb	w28, [x21, w15, uxtw #0]
+    __ strh(r23, Address(r21, r1, Address::sxtx(0)));  //	strh	w23, [x21, x1, sxtx #0]
+    __ ldr(r25, Address(r8, r11, Address::uxtw(0)));   //	ldr	x25, [x8, w11, uxtw #0]
+    __ ldrw(r13, Address(r8, r9, Address::lsl(0)));    //	ldr	w13, [x8, x9, lsl #0]
+    __ ldrb(r30, Address(r27, r9, Address::uxtw(0)));  //	ldrb	w30, [x27, w9, uxtw #0]
+    __ ldrh(r5, Address(r20, r17, Address::sxtw(0)));  //	ldrh	w5, [x20, w17, sxtw #0]
+    __ ldrsb(r11, Address(r3, r22, Address::lsl(0)));  //	ldrsb	x11, [x3, x22, lsl #0]
+    __ ldrsh(r20, Address(r20, r15, Address::sxtw(1))); //	ldrsh	x20, [x20, w15, sxtw #1]
+    __ ldrshw(r0, Address(r30, r1, Address::uxtw(0))); //	ldrsh	w0, [x30, w1, uxtw #0]
+    __ ldrsw(r11, Address(r11, r15, Address::sxtx(0))); //	ldrsw	x11, [x11, x15, sxtx #0]
+    __ ldrd(v24, Address(r1, r3, Address::lsl(0)));    //	ldr	d24, [x1, x3, lsl #0]
+    __ ldrs(v10, Address(r17, r9, Address::sxtx(0)));  //	ldr	s10, [x17, x9, sxtx #0]
+    __ strd(v6, Address(r13, r20, Address::sxtw(0)));  //	str	d6, [x13, w20, sxtw #0]
+    __ strs(v25, Address(r29, r5, Address::sxtx(0)));  //	str	s25, [x29, x5, sxtx #0]
 
 // base_plus_scaled_offset
 // LoadStoreOp
-    __ str(r5, Address(r8, 12600));                    //       str     x5, [x8, 12600]
-    __ strw(r29, Address(r24, 7880));                  //       str     w29, [x24, 7880]
-    __ strb(r19, Address(r17, 1566));                  //       strb    w19, [x17, 1566]
-    __ strh(r13, Address(r19, 3984));                  //       strh    w13, [x19, 3984]
-    __ ldr(r19, Address(r23, 13632));                  //       ldr     x19, [x23, 13632]
-    __ ldrw(r23, Address(r29, 6264));                  //       ldr     w23, [x29, 6264]
-    __ ldrb(r22, Address(r11, 2012));                  //       ldrb    w22, [x11, 2012]
-    __ ldrh(r3, Address(r10, 3784));                   //       ldrh    w3, [x10, 3784]
-    __ ldrsb(r8, Address(r16, 1951));                  //       ldrsb   x8, [x16, 1951]
-    __ ldrsh(r23, Address(r20, 3346));                 //       ldrsh   x23, [x20, 3346]
-    __ ldrshw(r2, Address(r1, 3994));                  //       ldrsh   w2, [x1, 3994]
-    __ ldrsw(r4, Address(r17, 7204));                  //       ldrsw   x4, [x17, 7204]
-    __ ldrd(v20, Address(r27, 14400));                 //       ldr     d20, [x27, 14400]
-    __ ldrs(v25, Address(r14, 8096));                  //       ldr     s25, [x14, 8096]
-    __ strd(v26, Address(r10, 15024));                 //       str     d26, [x10, 15024]
-    __ strs(v9, Address(r3, 6936));                    //       str     s9, [x3, 6936]
+    __ str(r20, Address(r6, 14552));                   //	str	x20, [x6, 14552]
+    __ strw(r19, Address(r2, 7564));                   //	str	w19, [x2, 7564]
+    __ strb(r20, Address(r2, 1866));                   //	strb	w20, [x2, 1866]
+    __ strh(r8, Address(r22, 3810));                   //	strh	w8, [x22, 3810]
+    __ ldr(r11, Address(r22, 13000));                  //	ldr	x11, [x22, 13000]
+    __ ldrw(r17, Address(r0, 7600));                   //	ldr	w17, [x0, 7600]
+    __ ldrb(r10, Address(r29, 1745));                  //	ldrb	w10, [x29, 1745]
+    __ ldrh(r2, Address(r17, 3252));                   //	ldrh	w2, [x17, 3252]
+    __ ldrsb(r16, Address(r6, 1538));                  //	ldrsb	x16, [x6, 1538]
+    __ ldrsh(r29, Address(r27, 4054));                 //	ldrsh	x29, [x27, 4054]
+    __ ldrshw(r15, Address(r17, 3842));                //	ldrsh	w15, [x17, 3842]
+    __ ldrsw(r28, Address(r14, 6952));                 //	ldrsw	x28, [x14, 6952]
+    __ ldrd(v7, Address(r29, 14648));                  //	ldr	d7, [x29, 14648]
+    __ ldrs(v19, Address(r15, 7656));                  //	ldr	s19, [x15, 7656]
+    __ strd(v7, Address(r17, 15760));                  //	str	d7, [x17, 15760]
+    __ strs(v9, Address(r0, 7492));                    //	str	s9, [x0, 7492]
 
 // pcrel
 // LoadStoreOp
-    __ ldr(r27, forth);                                //       ldr     x27, forth
-    __ ldrw(r11, __ pc());                             //       ldr     w11, .
+    __ ldr(r12, forth);                                //	ldr	x12, forth
+    __ ldrw(r23, __ pc());                             //	ldr	w23, .
 
 // LoadStoreOp
-    __ prfm(Address(r3, -187));                        //       prfm    PLDL1KEEP, [x3, -187]
+    __ prfm(Address(r26, -133));                       //	prfm	PLDL1KEEP, [x26, -133]
 
 // LoadStoreOp
-    __ prfm(__ pc());                                  //       prfm    PLDL1KEEP, .
+    __ prfm(__ pc());                                  //	prfm	PLDL1KEEP, .
 
 // LoadStoreOp
-    __ prfm(Address(r29, r14, Address::lsl(0)));       //       prfm    PLDL1KEEP, [x29, x14, lsl #0]
+    __ prfm(Address(r4, r28, Address::lsl(0)));        //	prfm	PLDL1KEEP, [x4, x28, lsl #0]
 
 // LoadStoreOp
-    __ prfm(Address(r4, 13312));                       //       prfm    PLDL1KEEP, [x4, 13312]
+    __ prfm(Address(r29, 16136));                      //	prfm	PLDL1KEEP, [x29, 16136]
 
 // AddSubCarryOp
-    __ adcw(r21, r1, r7);                              //       adc     w21, w1, w7
-    __ adcsw(r8, r5, r7);                              //       adcs    w8, w5, w7
-    __ sbcw(r7, r27, r14);                             //       sbc     w7, w27, w14
-    __ sbcsw(r27, r4, r17);                            //       sbcs    w27, w4, w17
-    __ adc(r0, r28, r0);                               //       adc     x0, x28, x0
-    __ adcs(r12, r24, r30);                            //       adcs    x12, x24, x30
-    __ sbc(r0, r25, r15);                              //       sbc     x0, x25, x15
-    __ sbcs(r1, r24, r3);                              //       sbcs    x1, x24, x3
+    __ adcw(r12, r11, r19);                            //	adc	w12, w11, w19
+    __ adcsw(r17, r4, r20);                            //	adcs	w17, w4, w20
+    __ sbcw(r15, r28, r29);                            //	sbc	w15, w28, w29
+    __ sbcsw(r3, r19, r26);                            //	sbcs	w3, w19, w26
+    __ adc(r0, r16, r19);                              //	adc	x0, x16, x19
+    __ adcs(r11, r15, r14);                            //	adcs	x11, x15, x14
+    __ sbc(r9, r0, r30);                               //	sbc	x9, x0, x30
+    __ sbcs(r7, r17, r20);                             //	sbcs	x7, x17, x20
 
 // AddSubExtendedOp
-    __ addw(r17, r24, r20, ext::uxtb, 2);              //       add     w17, w24, w20, uxtb #2
-    __ addsw(r13, r28, r10, ext::uxth, 1);             //       adds    w13, w28, w10, uxth #1
-    __ sub(r15, r16, r2, ext::sxth, 2);                //       sub     x15, x16, x2, sxth #2
-    __ subsw(r29, r13, r13, ext::uxth, 2);             //       subs    w29, w13, w13, uxth #2
-    __ add(r12, r20, r12, ext::sxtw, 3);               //       add     x12, x20, x12, sxtw #3
-    __ adds(r30, r27, r11, ext::sxtb, 1);              //       adds    x30, x27, x11, sxtb #1
-    __ sub(r14, r7, r1, ext::sxtw, 2);                 //       sub     x14, x7, x1, sxtw #2
-    __ subs(r29, r3, r27, ext::sxth, 1);               //       subs    x29, x3, x27, sxth #1
+    __ addw(r5, r21, r28, ext::sxtx, 4);               //	add	w5, w21, w28, sxtx #4
+    __ addsw(r17, r10, r22, ext::sxtb, 1);             //	adds	w17, w10, w22, sxtb #1
+    __ sub(r4, r19, r12, ext::sxth, 2);                //	sub	x4, x19, x12, sxth #2
+    __ subsw(r25, r9, r12, ext::uxtx, 1);              //	subs	w25, w9, w12, uxtx #1
+    __ add(r1, r10, r23, ext::sxth, 2);                //	add	x1, x10, x23, sxth #2
+    __ adds(r27, r14, r21, ext::sxtb, 2);              //	adds	x27, x14, x21, sxtb #2
+    __ sub(r11, r21, r5, ext::uxtb, 3);                //	sub	x11, x21, x5, uxtb #3
+    __ subs(r11, r17, r17, ext::uxtw, 1);              //	subs	x11, x17, x17, uxtw #1
 
 // ConditionalCompareOp
-    __ ccmnw(r0, r13, 14u, Assembler::MI);             //       ccmn    w0, w13, #14, MI
-    __ ccmpw(r22, r17, 6u, Assembler::CC);             //       ccmp    w22, w17, #6, CC
-    __ ccmn(r17, r30, 14u, Assembler::VS);             //       ccmn    x17, x30, #14, VS
-    __ ccmp(r10, r19, 12u, Assembler::HI);             //       ccmp    x10, x19, #12, HI
+    __ ccmnw(r11, r0, 0u, Assembler::NE);              //	ccmn	w11, w0, #0, NE
+    __ ccmpw(r7, r1, 10u, Assembler::PL);              //	ccmp	w7, w1, #10, PL
+    __ ccmn(r2, r26, 13u, Assembler::LS);              //	ccmn	x2, x26, #13, LS
+    __ ccmp(r4, r28, 13u, Assembler::GT);              //	ccmp	x4, x28, #13, GT
 
 // ConditionalCompareImmedOp
-    __ ccmnw(r6, 18, 2, Assembler::LE);                //       ccmn    w6, #18, #2, LE
-    __ ccmpw(r9, 13, 4, Assembler::HI);                //       ccmp    w9, #13, #4, HI
-    __ ccmn(r21, 11, 11, Assembler::LO);               //       ccmn    x21, #11, #11, LO
-    __ ccmp(r4, 13, 2, Assembler::VC);                 //       ccmp    x4, #13, #2, VC
+    __ ccmnw(r4, 11, 9, Assembler::LS);                //	ccmn	w4, #11, #9, LS
+    __ ccmpw(r20, 24, 13, Assembler::HI);              //	ccmp	w20, #24, #13, HI
+    __ ccmn(r0, 29, 8, Assembler::LT);                 //	ccmn	x0, #29, #8, LT
+    __ ccmp(r24, 26, 3, Assembler::NE);                //	ccmp	x24, #26, #3, NE
 
 // ConditionalSelectOp
-    __ cselw(r12, r2, r22, Assembler::HI);             //       csel    w12, w2, w22, HI
-    __ csincw(r24, r16, r17, Assembler::HS);           //       csinc   w24, w16, w17, HS
-    __ csinvw(r6, r7, r16, Assembler::LT);             //       csinv   w6, w7, w16, LT
-    __ csnegw(r11, r27, r22, Assembler::LS);           //       csneg   w11, w27, w22, LS
-    __ csel(r10, r3, r29, Assembler::LT);              //       csel    x10, x3, x29, LT
-    __ csinc(r12, r26, r27, Assembler::CC);            //       csinc   x12, x26, x27, CC
-    __ csinv(r15, r10, r21, Assembler::GT);            //       csinv   x15, x10, x21, GT
-    __ csneg(r30, r23, r9, Assembler::GT);             //       csneg   x30, x23, x9, GT
+    __ cselw(r30, r12, r5, Assembler::EQ);             //	csel	w30, w12, w5, EQ
+    __ csincw(r16, r4, r19, Assembler::LO);            //	csinc	w16, w4, w19, LO
+    __ csinvw(r2, r10, r7, Assembler::CC);             //	csinv	w2, w10, w7, CC
+    __ csnegw(r7, r30, r0, Assembler::CC);             //	csneg	w7, w30, w0, CC
+    __ csel(r23, r25, r26, Assembler::CC);             //	csel	x23, x25, x26, CC
+    __ csinc(r22, r2, r13, Assembler::CS);             //	csinc	x22, x2, x13, CS
+    __ csinv(r19, r20, r14, Assembler::LO);            //	csinv	x19, x20, x14, LO
+    __ csneg(r19, r19, r1, Assembler::VS);             //	csneg	x19, x19, x1, VS
 
 // TwoRegOp
-    __ rbitw(r30, r10);                                //       rbit    w30, w10
-    __ rev16w(r29, r15);                               //       rev16   w29, w15
-    __ revw(r29, r30);                                 //       rev     w29, w30
-    __ clzw(r25, r21);                                 //       clz     w25, w21
-    __ clsw(r4, r0);                                   //       cls     w4, w0
-    __ rbit(r17, r21);                                 //       rbit    x17, x21
-    __ rev16(r29, r16);                                //       rev16   x29, x16
-    __ rev32(r21, r20);                                //       rev32   x21, x20
-    __ rev(r6, r19);                                   //       rev     x6, x19
-    __ clz(r30, r3);                                   //       clz     x30, x3
-    __ cls(r21, r19);                                  //       cls     x21, x19
+    __ rbitw(r10, r25);                                //	rbit	w10, w25
+    __ rev16w(r23, r23);                               //	rev16	w23, w23
+    __ revw(r12, r0);                                  //	rev	w12, w0
+    __ clzw(r20, r29);                                 //	clz	w20, w29
+    __ clsw(r28, r1);                                  //	cls	w28, w1
+    __ rbit(r15, r2);                                  //	rbit	x15, x2
+    __ rev16(r11, r9);                                 //	rev16	x11, x9
+    __ rev32(r21, r4);                                 //	rev32	x21, x4
+    __ rev(r14, r7);                                   //	rev	x14, x7
+    __ clz(r16, r11);                                  //	clz	x16, x11
+    __ cls(r5, r23);                                   //	cls	x5, x23
 
 // ThreeRegOp
-    __ udivw(r11, r24, r0);                            //       udiv    w11, w24, w0
-    __ sdivw(r27, r25, r14);                           //       sdiv    w27, w25, w14
-    __ lslvw(r3, r14, r17);                            //       lslv    w3, w14, w17
-    __ lsrvw(r7, r15, r24);                            //       lsrv    w7, w15, w24
-    __ asrvw(r28, r17, r25);                           //       asrv    w28, w17, w25
-    __ rorvw(r2, r26, r28);                            //       rorv    w2, w26, w28
-    __ udiv(r5, r25, r26);                             //       udiv    x5, x25, x26
-    __ sdiv(r27, r16, r17);                            //       sdiv    x27, x16, x17
-    __ lslv(r6, r21, r12);                             //       lslv    x6, x21, x12
-    __ lsrv(r0, r4, r12);                              //       lsrv    x0, x4, x12
-    __ asrv(r27, r17, r28);                            //       asrv    x27, x17, x28
-    __ rorv(r28, r2, r17);                             //       rorv    x28, x2, x17
-    __ umulh(r10, r15, r14);                           //       umulh   x10, x15, x14
-    __ smulh(r14, r3, r25);                            //       smulh   x14, x3, x25
+    __ udivw(r24, r12, r10);                           //	udiv	w24, w12, w10
+    __ sdivw(r8, r25, r15);                            //	sdiv	w8, w25, w15
+    __ lslvw(r30, r12, r0);                            //	lslv	w30, w12, w0
+    __ lsrvw(r9, r16, r28);                            //	lsrv	w9, w16, w28
+    __ asrvw(r9, r17, r15);                            //	asrv	w9, w17, w15
+    __ rorvw(r1, r24, r17);                            //	rorv	w1, w24, w17
+    __ udiv(r17, r17, r8);                             //	udiv	x17, x17, x8
+    __ sdiv(r29, r21, r1);                             //	sdiv	x29, x21, x1
+    __ lslv(r14, r12, r23);                            //	lslv	x14, x12, x23
+    __ lsrv(r3, r12, r11);                             //	lsrv	x3, x12, x11
+    __ asrv(r15, r1, r0);                              //	asrv	x15, x1, x0
+    __ rorv(r8, r23, r1);                              //	rorv	x8, x23, x1
+    __ umulh(r8, r21, r21);                            //	umulh	x8, x21, x21
+    __ smulh(r17, r22, r24);                           //	smulh	x17, x22, x24
 
 // FourRegMulOp
-    __ maddw(r15, r19, r14, r5);                       //       madd    w15, w19, w14, w5
-    __ msubw(r16, r4, r26, r25);                       //       msub    w16, w4, w26, w25
-    __ madd(r4, r2, r2, r12);                          //       madd    x4, x2, x2, x12
-    __ msub(r29, r17, r8, r7);                         //       msub    x29, x17, x8, x7
-    __ smaddl(r3, r4, r25, r4);                        //       smaddl  x3, w4, w25, x4
-    __ smsubl(r26, r25, r4, r17);                      //       smsubl  x26, w25, w4, x17
-    __ umaddl(r0, r26, r17, r23);                      //       umaddl  x0, w26, w17, x23
-    __ umsubl(r15, r21, r28, r17);                     //       umsubl  x15, w21, w28, x17
+    __ maddw(r29, r9, r21, r24);                       //	madd	w29, w9, w21, w24
+    __ msubw(r6, r24, r16, r16);                       //	msub	w6, w24, w16, w16
+    __ madd(r10, r12, r26, r8);                        //	madd	x10, x12, x26, x8
+    __ msub(r6, r3, r17, r10);                         //	msub	x6, x3, x17, x10
+    __ smaddl(r25, r30, r30, r29);                     //	smaddl	x25, w30, w30, x29
+    __ smsubl(r7, r17, r21, r23);                      //	smsubl	x7, w17, w21, x23
+    __ umaddl(r17, r21, r28, r11);                     //	umaddl	x17, w21, w28, x11
+    __ umsubl(r5, r29, r27, r28);                      //	umsubl	x5, w29, w27, x28
 
 // ThreeRegFloatOp
-    __ fabds(v27, v10, v3);                            //       fabd    s27, s10, s3
-    __ fmuls(v0, v7, v25);                             //       fmul    s0, s7, s25
-    __ fdivs(v9, v6, v15);                             //       fdiv    s9, s6, s15
-    __ fadds(v29, v15, v10);                           //       fadd    s29, s15, s10
-    __ fsubs(v2, v17, v7);                             //       fsub    s2, s17, s7
-    __ fabdd(v11, v11, v23);                           //       fabd    d11, d11, d23
-    __ fmuld(v7, v29, v23);                            //       fmul    d7, d29, d23
-    __ fdivd(v14, v27, v11);                           //       fdiv    d14, d27, d11
-    __ faddd(v11, v4, v24);                            //       fadd    d11, d4, d24
-    __ fsubd(v12, v15, v14);                           //       fsub    d12, d15, d14
+    __ fabds(v4, v10, v27);                            //	fabd	s4, s10, s27
+    __ fmuls(v23, v26, v0);                            //	fmul	s23, s26, s0
+    __ fdivs(v17, v26, v1);                            //	fdiv	s17, s26, s1
+    __ fadds(v17, v4, v30);                            //	fadd	s17, s4, s30
+    __ fsubs(v11, v11, v9);                            //	fsub	s11, s11, s9
+    __ fabdd(v20, v9, v10);                            //	fabd	d20, d9, d10
+    __ fmuld(v15, v25, v12);                           //	fmul	d15, d25, d12
+    __ fdivd(v19, v13, v5);                            //	fdiv	d19, d13, d5
+    __ faddd(v0, v25, v4);                             //	fadd	d0, d25, d4
+    __ fsubd(v17, v1, v14);                            //	fsub	d17, d1, d14
 
 // FourRegFloatOp
-    __ fmadds(v20, v11, v28, v13);                     //       fmadd   s20, s11, s28, s13
-    __ fmsubs(v11, v12, v23, v30);                     //       fmsub   s11, s12, s23, s30
-    __ fnmadds(v26, v14, v9, v13);                     //       fnmadd  s26, s14, s9, s13
-    __ fnmadds(v10, v7, v5, v29);                      //       fnmadd  s10, s7, s5, s29
-    __ fmaddd(v15, v3, v11, v12);                      //       fmadd   d15, d3, d11, d12
-    __ fmsubd(v15, v30, v30, v17);                     //       fmsub   d15, d30, d30, d17
-    __ fnmaddd(v19, v20, v15, v15);                    //       fnmadd  d19, d20, d15, d15
-    __ fnmaddd(v9, v21, v2, v9);                       //       fnmadd  d9, d21, d2, d9
+    __ fmadds(v4, v10, v29, v0);                       //	fmadd	s4, s10, s29, s0
+    __ fmsubs(v30, v23, v15, v29);                     //	fmsub	s30, s23, s15, s29
+    __ fnmadds(v30, v21, v26, v21);                    //	fnmadd	s30, s21, s26, s21
+    __ fnmadds(v24, v8, v23, v19);                     //	fnmadd	s24, s8, s23, s19
+    __ fmaddd(v6, v2, v17, v29);                       //	fmadd	d6, d2, d17, d29
+    __ fmsubd(v13, v8, v30, v26);                      //	fmsub	d13, d8, d30, d26
+    __ fnmaddd(v5, v16, v5, v2);                       //	fnmadd	d5, d16, d5, d2
+    __ fnmaddd(v21, v20, v5, v17);                     //	fnmadd	d21, d20, d5, d17
 
 // TwoRegFloatOp
-    __ fmovs(v27, v7);                                 //       fmov    s27, s7
-    __ fabss(v29, v30);                                //       fabs    s29, s30
-    __ fnegs(v17, v1);                                 //       fneg    s17, s1
-    __ fsqrts(v2, v6);                                 //       fsqrt   s2, s6
-    __ fcvts(v10, v3);                                 //       fcvt    d10, s3
-    __ fmovd(v24, v11);                                //       fmov    d24, d11
-    __ fabsd(v7, v1);                                  //       fabs    d7, d1
-    __ fnegd(v11, v0);                                 //       fneg    d11, d0
-    __ fsqrtd(v3, v17);                                //       fsqrt   d3, d17
-    __ fcvtd(v28, v6);                                 //       fcvt    s28, d6
+    __ fmovs(v3, v30);                                 //	fmov	s3, s30
+    __ fabss(v16, v20);                                //	fabs	s16, s20
+    __ fnegs(v25, v17);                                //	fneg	s25, s17
+    __ fsqrts(v19, v12);                               //	fsqrt	s19, s12
+    __ fcvts(v24, v13);                                //	fcvt	d24, s13
+    __ fmovd(v8, v9);                                  //	fmov	d8, d9
+    __ fabsd(v9, v0);                                  //	fabs	d9, d0
+    __ fnegd(v13, v24);                                //	fneg	d13, d24
+    __ fsqrtd(v26, v22);                               //	fsqrt	d26, d22
+    __ fcvtd(v8, v30);                                 //	fcvt	s8, d30
 
 // FloatConvertOp
-    __ fcvtzsw(r22, v6);                               //       fcvtzs  w22, s6
-    __ fcvtzs(r0, v27);                                //       fcvtzs  x0, s27
-    __ fcvtzdw(r26, v2);                               //       fcvtzs  w26, d2
-    __ fcvtzd(r5, v7);                                 //       fcvtzs  x5, d7
-    __ scvtfws(v28, r11);                              //       scvtf   s28, w11
-    __ scvtfs(v25, r13);                               //       scvtf   s25, x13
-    __ scvtfwd(v11, r23);                              //       scvtf   d11, w23
-    __ scvtfd(v19, r8);                                //       scvtf   d19, x8
-    __ fmovs(r17, v21);                                //       fmov    w17, s21
-    __ fmovd(r25, v20);                                //       fmov    x25, d20
-    __ fmovs(v19, r17);                                //       fmov    s19, w17
-    __ fmovd(v2, r29);                                 //       fmov    d2, x29
+    __ fcvtzsw(r8, v17);                               //	fcvtzs	w8, s17
+    __ fcvtzs(r16, v17);                               //	fcvtzs	x16, s17
+    __ fcvtzdw(r10, v10);                              //	fcvtzs	w10, d10
+    __ fcvtzd(r6, v22);                                //	fcvtzs	x6, d22
+    __ scvtfws(v25, r13);                              //	scvtf	s25, w13
+    __ scvtfs(v25, r4);                                //	scvtf	s25, x4
+    __ scvtfwd(v27, r0);                               //	scvtf	d27, w0
+    __ scvtfd(v24, r16);                               //	scvtf	d24, x16
+    __ fmovs(r4, v25);                                 //	fmov	w4, s25
+    __ fmovd(r21, v22);                                //	fmov	x21, d22
+    __ fmovs(v29, r25);                                //	fmov	s29, w25
+    __ fmovd(v17, r12);                                //	fmov	d17, x12
 
 // TwoRegFloatOp
-    __ fcmps(v22, v8);                                 //       fcmp    s22, s8
-    __ fcmpd(v21, v19);                                //       fcmp    d21, d19
-    __ fcmps(v20, 0.0);                                //       fcmp    s20, #0.0
-    __ fcmpd(v11, 0.0);                                //       fcmp    d11, #0.0
+    __ fcmps(v11, v14);                                //	fcmp	s11, s14
+    __ fcmpd(v30, v1);                                 //	fcmp	d30, d1
+    __ fcmps(v17, 0.0);                                //	fcmp	s17, #0.0
+    __ fcmpd(v29, 0.0);                                //	fcmp	d29, #0.0
 
 // LoadStorePairOp
-    __ stpw(r20, r6, Address(r15, -32));               //       stp     w20, w6, [x15, #-32]
-    __ ldpw(r27, r14, Address(r3, -208));              //       ldp     w27, w14, [x3, #-208]
-    __ ldpsw(r16, r10, Address(r11, -80));             //       ldpsw   x16, x10, [x11, #-80]
-    __ stp(r7, r7, Address(r14, 64));                  //       stp     x7, x7, [x14, #64]
-    __ ldp(r12, r23, Address(r0, 112));                //       ldp     x12, x23, [x0, #112]
+    __ stpw(r20, r19, Address(r25, -48));              //	stp	w20, w19, [x25, #-48]
+    __ ldpw(r11, r16, Address(r0, 128));               //	ldp	w11, w16, [x0, #128]
+    __ ldpsw(r11, r21, Address(r20, -176));            //	ldpsw	x11, x21, [x20, #-176]
+    __ stp(r15, r0, Address(r23, 96));                 //	stp	x15, x0, [x23, #96]
+    __ ldp(r7, r8, Address(r28, 112));                 //	ldp	x7, x8, [x28, #112]
 
 // LoadStorePairOp
-    __ stpw(r13, r7, Address(__ pre(r6, -80)));        //       stp     w13, w7, [x6, #-80]!
-    __ ldpw(r30, r15, Address(__ pre(r2, -144)));      //       ldp     w30, w15, [x2, #-144]!
-    __ ldpsw(r4, r1, Address(__ pre(r27, -144)));      //       ldpsw   x4, x1, [x27, #-144]!
-    __ stp(r23, r14, Address(__ pre(r11, 64)));        //       stp     x23, x14, [x11, #64]!
-    __ ldp(r29, r27, Address(__ pre(r21, -192)));      //       ldp     x29, x27, [x21, #-192]!
+    __ stpw(r30, r24, Address(__ pre(r13, -176)));     //	stp	w30, w24, [x13, #-176]!
+    __ ldpw(r24, r23, Address(__ pre(r14, -224)));     //	ldp	w24, w23, [x14, #-224]!
+    __ ldpsw(r23, r3, Address(__ pre(r6, 0)));         //	ldpsw	x23, x3, [x6, #0]!
+    __ stp(r14, r29, Address(__ pre(r13, -176)));      //	stp	x14, x29, [x13, #-176]!
+    __ ldp(r8, r13, Address(__ pre(r29, 64)));         //	ldp	x8, x13, [x29, #64]!
 
 // LoadStorePairOp
-    __ stpw(r22, r5, Address(__ post(r21, -48)));      //       stp     w22, w5, [x21], #-48
-    __ ldpw(r27, r17, Address(__ post(r6, -32)));      //       ldp     w27, w17, [x6], #-32
-    __ ldpsw(r16, r5, Address(__ post(r1, -80)));      //       ldpsw   x16, x5, [x1], #-80
-    __ stp(r13, r20, Address(__ post(r22, -208)));     //       stp     x13, x20, [x22], #-208
-    __ ldp(r30, r27, Address(__ post(r10, 80)));       //       ldp     x30, x27, [x10], #80
+    __ stpw(r24, r11, Address(__ post(r10, 128)));     //	stp	w24, w11, [x10], #128
+    __ ldpw(r0, r25, Address(__ post(r8, -224)));      //	ldp	w0, w25, [x8], #-224
+    __ ldpsw(r13, r25, Address(__ post(r21, -160)));   //	ldpsw	x13, x25, [x21], #-160
+    __ stp(r21, r12, Address(__ post(r29, 64)));       //	stp	x21, x12, [x29], #64
+    __ ldp(r27, r19, Address(__ post(r4, -240)));      //	ldp	x27, x19, [x4], #-240
 
 // LoadStorePairOp
-    __ stnpw(r5, r17, Address(r11, 16));               //       stnp    w5, w17, [x11, #16]
-    __ ldnpw(r14, r4, Address(r26, -96));              //       ldnp    w14, w4, [x26, #-96]
-    __ stnp(r23, r29, Address(r12, 32));               //       stnp    x23, x29, [x12, #32]
-    __ ldnp(r0, r6, Address(r21, -80));                //       ldnp    x0, x6, [x21, #-80]
+    __ stnpw(r22, r8, Address(r10, 32));               //	stnp	w22, w8, [x10, #32]
+    __ ldnpw(r16, r4, Address(r29, -256));             //	ldnp	w16, w4, [x29, #-256]
+    __ stnp(r2, r17, Address(r27, -240));              //	stnp	x2, x17, [x27, #-240]
+    __ ldnp(r6, r23, Address(r2, -80));                //	ldnp	x6, x23, [x2, #-80]
 
 // LdStNEONOp
-    __ ld1(v15, __ T8B, Address(r26));                 //       ld1     {v15.8B}, [x26]
-    __ ld1(v23, v24, __ T16B, Address(__ post(r11, 32))); //    ld1     {v23.16B, v24.16B}, [x11], 32
-    __ ld1(v8, v9, v10, __ T1D, Address(__ post(r23, r7))); //  ld1     {v8.1D, v9.1D, v10.1D}, [x23], x7
-    __ ld1(v19, v20, v21, v22, __ T8H, Address(__ post(r25, 64))); //   ld1     {v19.8H, v20.8H, v21.8H, v22.8H}, [x25], 64
-    __ ld1r(v29, __ T8B, Address(r17));                //       ld1r    {v29.8B}, [x17]
-    __ ld1r(v24, __ T4S, Address(__ post(r23, 4)));    //       ld1r    {v24.4S}, [x23], 4
-    __ ld1r(v10, __ T1D, Address(__ post(r5, r25)));   //       ld1r    {v10.1D}, [x5], x25
-    __ ld2(v17, v18, __ T2D, Address(r10));            //       ld2     {v17.2D, v18.2D}, [x10]
-    __ ld2(v12, v13, __ T4H, Address(__ post(r15, 16))); //     ld2     {v12.4H, v13.4H}, [x15], 16
-    __ ld2r(v25, v26, __ T16B, Address(r17));          //       ld2r    {v25.16B, v26.16B}, [x17]
-    __ ld2r(v1, v2, __ T2S, Address(__ post(r30, 8))); //       ld2r    {v1.2S, v2.2S}, [x30], 8
-    __ ld2r(v16, v17, __ T2D, Address(__ post(r17, r9))); //    ld2r    {v16.2D, v17.2D}, [x17], x9
-    __ ld3(v25, v26, v27, __ T4S, Address(__ post(r12, r2))); //        ld3     {v25.4S, v26.4S, v27.4S}, [x12], x2
-    __ ld3(v26, v27, v28, __ T2S, Address(r19));       //       ld3     {v26.2S, v27.2S, v28.2S}, [x19]
-    __ ld3r(v15, v16, v17, __ T8H, Address(r21));      //       ld3r    {v15.8H, v16.8H, v17.8H}, [x21]
-    __ ld3r(v25, v26, v27, __ T4S, Address(__ post(r13, 12))); //       ld3r    {v25.4S, v26.4S, v27.4S}, [x13], 12
-    __ ld3r(v14, v15, v16, __ T1D, Address(__ post(r28, r29))); //      ld3r    {v14.1D, v15.1D, v16.1D}, [x28], x29
-    __ ld4(v17, v18, v19, v20, __ T8H, Address(__ post(r29, 64))); //   ld4     {v17.8H, v18.8H, v19.8H, v20.8H}, [x29], 64
-    __ ld4(v27, v28, v29, v30, __ T8B, Address(__ post(r7, r0))); //    ld4     {v27.8B, v28.8B, v29.8B, v30.8B}, [x7], x0
-    __ ld4r(v24, v25, v26, v27, __ T8B, Address(r17)); //       ld4r    {v24.8B, v25.8B, v26.8B, v27.8B}, [x17]
-    __ ld4r(v0, v1, v2, v3, __ T4H, Address(__ post(r26, 8))); //       ld4r    {v0.4H, v1.4H, v2.4H, v3.4H}, [x26], 8
-    __ ld4r(v12, v13, v14, v15, __ T2S, Address(__ post(r25, r2))); //  ld4r    {v12.2S, v13.2S, v14.2S, v15.2S}, [x25], x2
+    __ ld1(v28, __ T8B, Address(r3));                  //	ld1	{v28.8B}, [x3]
+    __ ld1(v27, v28, __ T16B, Address(__ post(r4, 32))); //	ld1	{v27.16B, v28.16B}, [x4], 32
+    __ ld1(v26, v27, v28, __ T1D, Address(__ post(r9, r16))); //	ld1	{v26.1D, v27.1D, v28.1D}, [x9], x16
+    __ ld1(v2, v3, v4, v5, __ T8H, Address(__ post(r17, 64))); //	ld1	{v2.8H, v3.8H, v4.8H, v5.8H}, [x17], 64
+    __ ld1r(v29, __ T8B, Address(r17));                //	ld1r	{v29.8B}, [x17]
+    __ ld1r(v26, __ T4S, Address(__ post(r4, 4)));     //	ld1r	{v26.4S}, [x4], 4
+    __ ld1r(v22, __ T1D, Address(__ post(r30, r2)));   //	ld1r	{v22.1D}, [x30], x2
+    __ ld2(v0, v1, __ T2D, Address(r10));              //	ld2	{v0.2D, v1.2D}, [x10]
+    __ ld2(v26, v27, __ T4H, Address(__ post(r26, 16))); //	ld2	{v26.4H, v27.4H}, [x26], 16
+    __ ld2r(v23, v24, __ T16B, Address(r12));          //	ld2r	{v23.16B, v24.16B}, [x12]
+    __ ld2r(v25, v26, __ T2S, Address(__ post(r4, 8))); //	ld2r	{v25.2S, v26.2S}, [x4], 8
+    __ ld2r(v1, v2, __ T2D, Address(__ post(r12, r29))); //	ld2r	{v1.2D, v2.2D}, [x12], x29
+    __ ld3(v5, v6, v7, __ T4S, Address(__ post(r14, r11))); //	ld3	{v5.4S, v6.4S, v7.4S}, [x14], x11
+    __ ld3(v0, v1, v2, __ T2S, Address(r0));           //	ld3	{v0.2S, v1.2S, v2.2S}, [x0]
+    __ ld3r(v25, v26, v27, __ T8H, Address(r11));      //	ld3r	{v25.8H, v26.8H, v27.8H}, [x11]
+    __ ld3r(v0, v1, v2, __ T4S, Address(__ post(r17, 12))); //	ld3r	{v0.4S, v1.4S, v2.4S}, [x17], 12
+    __ ld3r(v4, v5, v6, __ T1D, Address(__ post(r20, r16))); //	ld3r	{v4.1D, v5.1D, v6.1D}, [x20], x16
+    __ ld4(v30, v31, v0, v1, __ T8H, Address(__ post(r29, 64))); //	ld4	{v30.8H, v31.8H, v0.8H, v1.8H}, [x29], 64
+    __ ld4(v15, v16, v17, v18, __ T8B, Address(__ post(r17, r22))); //	ld4	{v15.8B, v16.8B, v17.8B, v18.8B}, [x17], x22
+    __ ld4r(v10, v11, v12, v13, __ T8B, Address(r30)); //	ld4r	{v10.8B, v11.8B, v12.8B, v13.8B}, [x30]
+    __ ld4r(v28, v29, v30, v31, __ T4H, Address(__ post(r5, 8))); //	ld4r	{v28.4H, v29.4H, v30.4H, v31.4H}, [x5], 8
+    __ ld4r(v4, v5, v6, v7, __ T2S, Address(__ post(r17, r4))); //	ld4r	{v4.2S, v5.2S, v6.2S, v7.2S}, [x17], x4
 
 // NEONReduceInstruction
-    __ addv(v22, __ T8B, v23);                         //       addv    b22, v23.8B
-    __ addv(v27, __ T16B, v28);                        //       addv    b27, v28.16B
-    __ addv(v4, __ T4H, v5);                           //       addv    h4, v5.4H
-    __ addv(v7, __ T8H, v8);                           //       addv    h7, v8.8H
-    __ addv(v6, __ T4S, v7);                           //       addv    s6, v7.4S
-    __ smaxv(v1, __ T8B, v2);                          //       smaxv   b1, v2.8B
-    __ smaxv(v26, __ T16B, v27);                       //       smaxv   b26, v27.16B
-    __ smaxv(v15, __ T4H, v16);                        //       smaxv   h15, v16.4H
-    __ smaxv(v2, __ T8H, v3);                          //       smaxv   h2, v3.8H
-    __ smaxv(v13, __ T4S, v14);                        //       smaxv   s13, v14.4S
-    __ fmaxv(v13, __ T4S, v14);                        //       fmaxv   s13, v14.4S
-    __ sminv(v24, __ T8B, v25);                        //       sminv   b24, v25.8B
-    __ uminv(v23, __ T8B, v24);                        //       uminv   b23, v24.8B
-    __ sminv(v4, __ T16B, v5);                         //       sminv   b4, v5.16B
-    __ uminv(v19, __ T16B, v20);                       //       uminv   b19, v20.16B
-    __ sminv(v15, __ T4H, v16);                        //       sminv   h15, v16.4H
-    __ uminv(v0, __ T4H, v1);                          //       uminv   h0, v1.4H
-    __ sminv(v4, __ T8H, v5);                          //       sminv   h4, v5.8H
-    __ uminv(v20, __ T8H, v21);                        //       uminv   h20, v21.8H
-    __ sminv(v11, __ T4S, v12);                        //       sminv   s11, v12.4S
-    __ uminv(v29, __ T4S, v30);                        //       uminv   s29, v30.4S
-    __ fminv(v15, __ T4S, v16);                        //       fminv   s15, v16.4S
-    __ fmaxp(v21, v22, __ S);                          //       fmaxp   s21, v22.2S
-    __ fmaxp(v4, v5, __ D);                            //       fmaxp   d4, v5.2D
-    __ fminp(v14, v15, __ S);                          //       fminp   s14, v15.2S
-    __ fminp(v22, v23, __ D);                          //       fminp   d22, v23.2D
+    __ addv(v0, __ T8B, v1);                           //	addv	b0, v1.8B
+    __ addv(v0, __ T16B, v1);                          //	addv	b0, v1.16B
+    __ addv(v26, __ T4H, v27);                         //	addv	h26, v27.4H
+    __ addv(v10, __ T8H, v11);                         //	addv	h10, v11.8H
+    __ addv(v16, __ T4S, v17);                         //	addv	s16, v17.4S
+    __ smaxv(v0, __ T8B, v1);                          //	smaxv	b0, v1.8B
+    __ smaxv(v1, __ T16B, v2);                         //	smaxv	b1, v2.16B
+    __ smaxv(v1, __ T4H, v2);                          //	smaxv	h1, v2.4H
+    __ smaxv(v24, __ T8H, v25);                        //	smaxv	h24, v25.8H
+    __ smaxv(v29, __ T4S, v30);                        //	smaxv	s29, v30.4S
+    __ fmaxv(v3, __ T4S, v4);                          //	fmaxv	s3, v4.4S
+    __ sminv(v17, __ T8B, v18);                        //	sminv	b17, v18.8B
+    __ uminv(v19, __ T8B, v20);                        //	uminv	b19, v20.8B
+    __ sminv(v4, __ T16B, v5);                         //	sminv	b4, v5.16B
+    __ uminv(v24, __ T16B, v25);                       //	uminv	b24, v25.16B
+    __ sminv(v4, __ T4H, v5);                          //	sminv	h4, v5.4H
+    __ uminv(v21, __ T4H, v22);                        //	uminv	h21, v22.4H
+    __ sminv(v25, __ T8H, v26);                        //	sminv	h25, v26.8H
+    __ uminv(v12, __ T8H, v13);                        //	uminv	h12, v13.8H
+    __ sminv(v25, __ T4S, v26);                        //	sminv	s25, v26.4S
+    __ uminv(v0, __ T4S, v1);                          //	uminv	s0, v1.4S
+    __ fminv(v13, __ T4S, v14);                        //	fminv	s13, v14.4S
+    __ fmaxp(v13, v14, __ S);                          //	fmaxp	s13, v14.2S
+    __ fmaxp(v17, v18, __ D);                          //	fmaxp	d17, v18.2D
+    __ fminp(v29, v30, __ S);                          //	fminp	s29, v30.2S
+    __ fminp(v21, v22, __ D);                          //	fminp	d21, v22.2D
 
 // TwoRegNEONOp
-    __ absr(v25, __ T8B, v26);                         //       abs     v25.8B, v26.8B
-    __ absr(v6, __ T16B, v7);                          //       abs     v6.16B, v7.16B
-    __ absr(v12, __ T4H, v13);                         //       abs     v12.4H, v13.4H
-    __ absr(v14, __ T8H, v15);                         //       abs     v14.8H, v15.8H
-    __ absr(v13, __ T2S, v14);                         //       abs     v13.2S, v14.2S
-    __ absr(v14, __ T4S, v15);                         //       abs     v14.4S, v15.4S
-    __ absr(v9, __ T2D, v10);                          //       abs     v9.2D, v10.2D
-    __ fabs(v25, __ T2S, v26);                         //       fabs    v25.2S, v26.2S
-    __ fabs(v28, __ T4S, v29);                         //       fabs    v28.4S, v29.4S
-    __ fabs(v10, __ T2D, v11);                         //       fabs    v10.2D, v11.2D
-    __ fneg(v19, __ T2S, v20);                         //       fneg    v19.2S, v20.2S
-    __ fneg(v11, __ T4S, v12);                         //       fneg    v11.4S, v12.4S
-    __ fneg(v17, __ T2D, v18);                         //       fneg    v17.2D, v18.2D
-    __ fsqrt(v21, __ T2S, v22);                        //       fsqrt   v21.2S, v22.2S
-    __ fsqrt(v15, __ T4S, v16);                        //       fsqrt   v15.4S, v16.4S
-    __ fsqrt(v20, __ T2D, v21);                        //       fsqrt   v20.2D, v21.2D
-    __ notr(v23, __ T8B, v24);                         //       not     v23.8B, v24.8B
-    __ notr(v26, __ T16B, v27);                        //       not     v26.16B, v27.16B
+    __ absr(v10, __ T8B, v11);                         //	abs	v10.8B, v11.8B
+    __ absr(v22, __ T16B, v23);                        //	abs	v22.16B, v23.16B
+    __ absr(v7, __ T4H, v8);                           //	abs	v7.4H, v8.4H
+    __ absr(v29, __ T8H, v30);                         //	abs	v29.8H, v30.8H
+    __ absr(v4, __ T2S, v5);                           //	abs	v4.2S, v5.2S
+    __ absr(v11, __ T4S, v12);                         //	abs	v11.4S, v12.4S
+    __ absr(v16, __ T2D, v17);                         //	abs	v16.2D, v17.2D
+    __ fabs(v6, __ T2S, v7);                           //	fabs	v6.2S, v7.2S
+    __ fabs(v17, __ T4S, v18);                         //	fabs	v17.4S, v18.4S
+    __ fabs(v12, __ T2D, v13);                         //	fabs	v12.2D, v13.2D
+    __ fneg(v2, __ T2S, v3);                           //	fneg	v2.2S, v3.2S
+    __ fneg(v4, __ T4S, v5);                           //	fneg	v4.4S, v5.4S
+    __ fneg(v13, __ T2D, v14);                         //	fneg	v13.2D, v14.2D
+    __ fsqrt(v17, __ T2S, v18);                        //	fsqrt	v17.2S, v18.2S
+    __ fsqrt(v21, __ T4S, v22);                        //	fsqrt	v21.4S, v22.4S
+    __ fsqrt(v11, __ T2D, v12);                        //	fsqrt	v11.2D, v12.2D
+    __ notr(v30, __ T8B, v31);                         //	not	v30.8B, v31.8B
+    __ notr(v3, __ T16B, v4);                          //	not	v3.16B, v4.16B
 
 // ThreeRegNEONOp
-    __ andr(v5, __ T8B, v6, v7);                       //       and     v5.8B, v6.8B, v7.8B
-    __ andr(v6, __ T16B, v7, v8);                      //       and     v6.16B, v7.16B, v8.16B
-    __ orr(v15, __ T8B, v16, v17);                     //       orr     v15.8B, v16.8B, v17.8B
-    __ orr(v15, __ T16B, v16, v17);                    //       orr     v15.16B, v16.16B, v17.16B
-    __ eor(v25, __ T8B, v26, v27);                     //       eor     v25.8B, v26.8B, v27.8B
-    __ eor(v16, __ T16B, v17, v18);                    //       eor     v16.16B, v17.16B, v18.16B
-    __ addv(v27, __ T8B, v28, v29);                    //       add     v27.8B, v28.8B, v29.8B
-    __ addv(v24, __ T16B, v25, v26);                   //       add     v24.16B, v25.16B, v26.16B
-    __ addv(v15, __ T4H, v16, v17);                    //       add     v15.4H, v16.4H, v17.4H
-    __ addv(v25, __ T8H, v26, v27);                    //       add     v25.8H, v26.8H, v27.8H
-    __ addv(v14, __ T2S, v15, v16);                    //       add     v14.2S, v15.2S, v16.2S
-    __ addv(v10, __ T4S, v11, v12);                    //       add     v10.4S, v11.4S, v12.4S
-    __ addv(v13, __ T2D, v14, v15);                    //       add     v13.2D, v14.2D, v15.2D
-    __ fadd(v14, __ T2S, v15, v16);                    //       fadd    v14.2S, v15.2S, v16.2S
-    __ fadd(v20, __ T4S, v21, v22);                    //       fadd    v20.4S, v21.4S, v22.4S
-    __ fadd(v1, __ T2D, v2, v3);                       //       fadd    v1.2D, v2.2D, v3.2D
-    __ subv(v22, __ T8B, v23, v24);                    //       sub     v22.8B, v23.8B, v24.8B
-    __ subv(v30, __ T16B, v31, v0);                    //       sub     v30.16B, v31.16B, v0.16B
-    __ subv(v14, __ T4H, v15, v16);                    //       sub     v14.4H, v15.4H, v16.4H
-    __ subv(v2, __ T8H, v3, v4);                       //       sub     v2.8H, v3.8H, v4.8H
-    __ subv(v6, __ T2S, v7, v8);                       //       sub     v6.2S, v7.2S, v8.2S
-    __ subv(v3, __ T4S, v4, v5);                       //       sub     v3.4S, v4.4S, v5.4S
-    __ subv(v7, __ T2D, v8, v9);                       //       sub     v7.2D, v8.2D, v9.2D
-    __ fsub(v24, __ T2S, v25, v26);                    //       fsub    v24.2S, v25.2S, v26.2S
-    __ fsub(v0, __ T4S, v1, v2);                       //       fsub    v0.4S, v1.4S, v2.4S
-    __ fsub(v27, __ T2D, v28, v29);                    //       fsub    v27.2D, v28.2D, v29.2D
-    __ mulv(v29, __ T8B, v30, v31);                    //       mul     v29.8B, v30.8B, v31.8B
-    __ mulv(v5, __ T16B, v6, v7);                      //       mul     v5.16B, v6.16B, v7.16B
-    __ mulv(v5, __ T4H, v6, v7);                       //       mul     v5.4H, v6.4H, v7.4H
-    __ mulv(v29, __ T8H, v30, v31);                    //       mul     v29.8H, v30.8H, v31.8H
-    __ mulv(v11, __ T2S, v12, v13);                    //       mul     v11.2S, v12.2S, v13.2S
-    __ mulv(v25, __ T4S, v26, v27);                    //       mul     v25.4S, v26.4S, v27.4S
-    __ fabd(v0, __ T2S, v1, v2);                       //       fabd    v0.2S, v1.2S, v2.2S
-    __ fabd(v30, __ T4S, v31, v0);                     //       fabd    v30.4S, v31.4S, v0.4S
-    __ fabd(v0, __ T2D, v1, v2);                       //       fabd    v0.2D, v1.2D, v2.2D
-    __ fmul(v17, __ T2S, v18, v19);                    //       fmul    v17.2S, v18.2S, v19.2S
-    __ fmul(v28, __ T4S, v29, v30);                    //       fmul    v28.4S, v29.4S, v30.4S
-    __ fmul(v25, __ T2D, v26, v27);                    //       fmul    v25.2D, v26.2D, v27.2D
-    __ mlav(v9, __ T4H, v10, v11);                     //       mla     v9.4H, v10.4H, v11.4H
-    __ mlav(v25, __ T8H, v26, v27);                    //       mla     v25.8H, v26.8H, v27.8H
-    __ mlav(v12, __ T2S, v13, v14);                    //       mla     v12.2S, v13.2S, v14.2S
-    __ mlav(v15, __ T4S, v16, v17);                    //       mla     v15.4S, v16.4S, v17.4S
-    __ fmla(v11, __ T2S, v12, v13);                    //       fmla    v11.2S, v12.2S, v13.2S
-    __ fmla(v10, __ T4S, v11, v12);                    //       fmla    v10.4S, v11.4S, v12.4S
-    __ fmla(v17, __ T2D, v18, v19);                    //       fmla    v17.2D, v18.2D, v19.2D
-    __ mlsv(v24, __ T4H, v25, v26);                    //       mls     v24.4H, v25.4H, v26.4H
-    __ mlsv(v21, __ T8H, v22, v23);                    //       mls     v21.8H, v22.8H, v23.8H
-    __ mlsv(v23, __ T2S, v24, v25);                    //       mls     v23.2S, v24.2S, v25.2S
-    __ mlsv(v0, __ T4S, v1, v2);                       //       mls     v0.4S, v1.4S, v2.4S
-    __ fmls(v16, __ T2S, v17, v18);                    //       fmls    v16.2S, v17.2S, v18.2S
-    __ fmls(v10, __ T4S, v11, v12);                    //       fmls    v10.4S, v11.4S, v12.4S
-    __ fmls(v6, __ T2D, v7, v8);                       //       fmls    v6.2D, v7.2D, v8.2D
-    __ fdiv(v28, __ T2S, v29, v30);                    //       fdiv    v28.2S, v29.2S, v30.2S
-    __ fdiv(v6, __ T4S, v7, v8);                       //       fdiv    v6.4S, v7.4S, v8.4S
-    __ fdiv(v5, __ T2D, v6, v7);                       //       fdiv    v5.2D, v6.2D, v7.2D
-    __ maxv(v5, __ T8B, v6, v7);                       //       smax    v5.8B, v6.8B, v7.8B
-    __ maxv(v20, __ T16B, v21, v22);                   //       smax    v20.16B, v21.16B, v22.16B
-    __ maxv(v17, __ T4H, v18, v19);                    //       smax    v17.4H, v18.4H, v19.4H
-    __ maxv(v15, __ T8H, v16, v17);                    //       smax    v15.8H, v16.8H, v17.8H
-    __ maxv(v17, __ T2S, v18, v19);                    //       smax    v17.2S, v18.2S, v19.2S
-    __ maxv(v29, __ T4S, v30, v31);                    //       smax    v29.4S, v30.4S, v31.4S
-    __ smaxp(v26, __ T8B, v27, v28);                   //       smaxp   v26.8B, v27.8B, v28.8B
-    __ smaxp(v28, __ T16B, v29, v30);                  //       smaxp   v28.16B, v29.16B, v30.16B
-    __ smaxp(v1, __ T4H, v2, v3);                      //       smaxp   v1.4H, v2.4H, v3.4H
-    __ smaxp(v27, __ T8H, v28, v29);                   //       smaxp   v27.8H, v28.8H, v29.8H
-    __ smaxp(v0, __ T2S, v1, v2);                      //       smaxp   v0.2S, v1.2S, v2.2S
-    __ smaxp(v20, __ T4S, v21, v22);                   //       smaxp   v20.4S, v21.4S, v22.4S
-    __ fmax(v28, __ T2S, v29, v30);                    //       fmax    v28.2S, v29.2S, v30.2S
-    __ fmax(v15, __ T4S, v16, v17);                    //       fmax    v15.4S, v16.4S, v17.4S
-    __ fmax(v12, __ T2D, v13, v14);                    //       fmax    v12.2D, v13.2D, v14.2D
-    __ minv(v10, __ T8B, v11, v12);                    //       smin    v10.8B, v11.8B, v12.8B
-    __ minv(v28, __ T16B, v29, v30);                   //       smin    v28.16B, v29.16B, v30.16B
-    __ minv(v28, __ T4H, v29, v30);                    //       smin    v28.4H, v29.4H, v30.4H
-    __ minv(v19, __ T8H, v20, v21);                    //       smin    v19.8H, v20.8H, v21.8H
-    __ minv(v22, __ T2S, v23, v24);                    //       smin    v22.2S, v23.2S, v24.2S
-    __ minv(v10, __ T4S, v11, v12);                    //       smin    v10.4S, v11.4S, v12.4S
-    __ sminp(v4, __ T8B, v5, v6);                      //       sminp   v4.8B, v5.8B, v6.8B
-    __ sminp(v30, __ T16B, v31, v0);                   //       sminp   v30.16B, v31.16B, v0.16B
-    __ sminp(v20, __ T4H, v21, v22);                   //       sminp   v20.4H, v21.4H, v22.4H
-    __ sminp(v8, __ T8H, v9, v10);                     //       sminp   v8.8H, v9.8H, v10.8H
-    __ sminp(v30, __ T2S, v31, v0);                    //       sminp   v30.2S, v31.2S, v0.2S
-    __ sminp(v17, __ T4S, v18, v19);                   //       sminp   v17.4S, v18.4S, v19.4S
-    __ fmin(v10, __ T2S, v11, v12);                    //       fmin    v10.2S, v11.2S, v12.2S
-    __ fmin(v27, __ T4S, v28, v29);                    //       fmin    v27.4S, v28.4S, v29.4S
-    __ fmin(v2, __ T2D, v3, v4);                       //       fmin    v2.2D, v3.2D, v4.2D
-    __ cmeq(v24, __ T8B, v25, v26);                    //       cmeq    v24.8B, v25.8B, v26.8B
-    __ cmeq(v4, __ T16B, v5, v6);                      //       cmeq    v4.16B, v5.16B, v6.16B
-    __ cmeq(v3, __ T4H, v4, v5);                       //       cmeq    v3.4H, v4.4H, v5.4H
-    __ cmeq(v8, __ T8H, v9, v10);                      //       cmeq    v8.8H, v9.8H, v10.8H
-    __ cmeq(v22, __ T2S, v23, v24);                    //       cmeq    v22.2S, v23.2S, v24.2S
-    __ cmeq(v17, __ T4S, v18, v19);                    //       cmeq    v17.4S, v18.4S, v19.4S
-    __ cmeq(v13, __ T2D, v14, v15);                    //       cmeq    v13.2D, v14.2D, v15.2D
-    __ fcmeq(v4, __ T2S, v5, v6);                      //       fcmeq   v4.2S, v5.2S, v6.2S
-    __ fcmeq(v28, __ T4S, v29, v30);                   //       fcmeq   v28.4S, v29.4S, v30.4S
-    __ fcmeq(v23, __ T2D, v24, v25);                   //       fcmeq   v23.2D, v24.2D, v25.2D
-    __ cmgt(v21, __ T8B, v22, v23);                    //       cmgt    v21.8B, v22.8B, v23.8B
-    __ cmgt(v25, __ T16B, v26, v27);                   //       cmgt    v25.16B, v26.16B, v27.16B
-    __ cmgt(v24, __ T4H, v25, v26);                    //       cmgt    v24.4H, v25.4H, v26.4H
-    __ cmgt(v3, __ T8H, v4, v5);                       //       cmgt    v3.8H, v4.8H, v5.8H
-    __ cmgt(v23, __ T2S, v24, v25);                    //       cmgt    v23.2S, v24.2S, v25.2S
-    __ cmgt(v26, __ T4S, v27, v28);                    //       cmgt    v26.4S, v27.4S, v28.4S
-    __ cmgt(v23, __ T2D, v24, v25);                    //       cmgt    v23.2D, v24.2D, v25.2D
-    __ cmhi(v14, __ T8B, v15, v16);                    //       cmhi    v14.8B, v15.8B, v16.8B
-    __ cmhi(v21, __ T16B, v22, v23);                   //       cmhi    v21.16B, v22.16B, v23.16B
-    __ cmhi(v3, __ T4H, v4, v5);                       //       cmhi    v3.4H, v4.4H, v5.4H
-    __ cmhi(v23, __ T8H, v24, v25);                    //       cmhi    v23.8H, v24.8H, v25.8H
-    __ cmhi(v8, __ T2S, v9, v10);                      //       cmhi    v8.2S, v9.2S, v10.2S
-    __ cmhi(v24, __ T4S, v25, v26);                    //       cmhi    v24.4S, v25.4S, v26.4S
-    __ cmhi(v19, __ T2D, v20, v21);                    //       cmhi    v19.2D, v20.2D, v21.2D
-    __ cmhs(v15, __ T8B, v16, v17);                    //       cmhs    v15.8B, v16.8B, v17.8B
-    __ cmhs(v16, __ T16B, v17, v18);                   //       cmhs    v16.16B, v17.16B, v18.16B
-    __ cmhs(v2, __ T4H, v3, v4);                       //       cmhs    v2.4H, v3.4H, v4.4H
-    __ cmhs(v1, __ T8H, v2, v3);                       //       cmhs    v1.8H, v2.8H, v3.8H
-    __ cmhs(v0, __ T2S, v1, v2);                       //       cmhs    v0.2S, v1.2S, v2.2S
-    __ cmhs(v24, __ T4S, v25, v26);                    //       cmhs    v24.4S, v25.4S, v26.4S
-    __ cmhs(v4, __ T2D, v5, v6);                       //       cmhs    v4.2D, v5.2D, v6.2D
-    __ fcmgt(v3, __ T2S, v4, v5);                      //       fcmgt   v3.2S, v4.2S, v5.2S
-    __ fcmgt(v11, __ T4S, v12, v13);                   //       fcmgt   v11.4S, v12.4S, v13.4S
-    __ fcmgt(v30, __ T2D, v31, v0);                    //       fcmgt   v30.2D, v31.2D, v0.2D
-    __ cmge(v27, __ T8B, v28, v29);                    //       cmge    v27.8B, v28.8B, v29.8B
-    __ cmge(v9, __ T16B, v10, v11);                    //       cmge    v9.16B, v10.16B, v11.16B
-    __ cmge(v25, __ T4H, v26, v27);                    //       cmge    v25.4H, v26.4H, v27.4H
-    __ cmge(v2, __ T8H, v3, v4);                       //       cmge    v2.8H, v3.8H, v4.8H
-    __ cmge(v12, __ T2S, v13, v14);                    //       cmge    v12.2S, v13.2S, v14.2S
-    __ cmge(v17, __ T4S, v18, v19);                    //       cmge    v17.4S, v18.4S, v19.4S
-    __ cmge(v30, __ T2D, v31, v0);                     //       cmge    v30.2D, v31.2D, v0.2D
-    __ fcmge(v1, __ T2S, v2, v3);                      //       fcmge   v1.2S, v2.2S, v3.2S
-    __ fcmge(v12, __ T4S, v13, v14);                   //       fcmge   v12.4S, v13.4S, v14.4S
-    __ fcmge(v28, __ T2D, v29, v30);                   //       fcmge   v28.2D, v29.2D, v30.2D
+    __ andr(v13, __ T8B, v14, v15);                    //	and	v13.8B, v14.8B, v15.8B
+    __ andr(v28, __ T16B, v29, v30);                   //	and	v28.16B, v29.16B, v30.16B
+    __ orr(v13, __ T8B, v14, v15);                     //	orr	v13.8B, v14.8B, v15.8B
+    __ orr(v7, __ T16B, v8, v9);                       //	orr	v7.16B, v8.16B, v9.16B
+    __ eor(v15, __ T8B, v16, v17);                     //	eor	v15.8B, v16.8B, v17.8B
+    __ eor(v12, __ T16B, v13, v14);                    //	eor	v12.16B, v13.16B, v14.16B
+    __ addv(v7, __ T8B, v8, v9);                       //	add	v7.8B, v8.8B, v9.8B
+    __ addv(v29, __ T16B, v30, v31);                   //	add	v29.16B, v30.16B, v31.16B
+    __ addv(v12, __ T4H, v13, v14);                    //	add	v12.4H, v13.4H, v14.4H
+    __ addv(v7, __ T8H, v8, v9);                       //	add	v7.8H, v8.8H, v9.8H
+    __ addv(v20, __ T2S, v21, v22);                    //	add	v20.2S, v21.2S, v22.2S
+    __ addv(v15, __ T4S, v16, v17);                    //	add	v15.4S, v16.4S, v17.4S
+    __ addv(v12, __ T2D, v13, v14);                    //	add	v12.2D, v13.2D, v14.2D
+    __ fadd(v29, __ T2S, v30, v31);                    //	fadd	v29.2S, v30.2S, v31.2S
+    __ fadd(v17, __ T4S, v18, v19);                    //	fadd	v17.4S, v18.4S, v19.4S
+    __ fadd(v2, __ T2D, v3, v4);                       //	fadd	v2.2D, v3.2D, v4.2D
+    __ subv(v26, __ T8B, v27, v28);                    //	sub	v26.8B, v27.8B, v28.8B
+    __ subv(v8, __ T16B, v9, v10);                     //	sub	v8.16B, v9.16B, v10.16B
+    __ subv(v8, __ T4H, v9, v10);                      //	sub	v8.4H, v9.4H, v10.4H
+    __ subv(v28, __ T8H, v29, v30);                    //	sub	v28.8H, v29.8H, v30.8H
+    __ subv(v16, __ T2S, v17, v18);                    //	sub	v16.2S, v17.2S, v18.2S
+    __ subv(v11, __ T4S, v12, v13);                    //	sub	v11.4S, v12.4S, v13.4S
+    __ subv(v17, __ T2D, v18, v19);                    //	sub	v17.2D, v18.2D, v19.2D
+    __ fsub(v0, __ T2S, v1, v2);                       //	fsub	v0.2S, v1.2S, v2.2S
+    __ fsub(v19, __ T4S, v20, v21);                    //	fsub	v19.4S, v20.4S, v21.4S
+    __ fsub(v19, __ T2D, v20, v21);                    //	fsub	v19.2D, v20.2D, v21.2D
+    __ mulv(v24, __ T8B, v25, v26);                    //	mul	v24.8B, v25.8B, v26.8B
+    __ mulv(v15, __ T16B, v16, v17);                   //	mul	v15.16B, v16.16B, v17.16B
+    __ mulv(v28, __ T4H, v29, v30);                    //	mul	v28.4H, v29.4H, v30.4H
+    __ mulv(v7, __ T8H, v8, v9);                       //	mul	v7.8H, v8.8H, v9.8H
+    __ mulv(v8, __ T2S, v9, v10);                      //	mul	v8.2S, v9.2S, v10.2S
+    __ mulv(v1, __ T4S, v2, v3);                       //	mul	v1.4S, v2.4S, v3.4S
+    __ fabd(v19, __ T2S, v20, v21);                    //	fabd	v19.2S, v20.2S, v21.2S
+    __ fabd(v10, __ T4S, v11, v12);                    //	fabd	v10.4S, v11.4S, v12.4S
+    __ fabd(v27, __ T2D, v28, v29);                    //	fabd	v27.2D, v28.2D, v29.2D
+    __ fmul(v25, __ T2S, v26, v27);                    //	fmul	v25.2S, v26.2S, v27.2S
+    __ fmul(v12, __ T4S, v13, v14);                    //	fmul	v12.4S, v13.4S, v14.4S
+    __ fmul(v30, __ T2D, v31, v0);                     //	fmul	v30.2D, v31.2D, v0.2D
+    __ mlav(v20, __ T4H, v21, v22);                    //	mla	v20.4H, v21.4H, v22.4H
+    __ mlav(v3, __ T8H, v4, v5);                       //	mla	v3.8H, v4.8H, v5.8H
+    __ mlav(v17, __ T2S, v18, v19);                    //	mla	v17.2S, v18.2S, v19.2S
+    __ mlav(v28, __ T4S, v29, v30);                    //	mla	v28.4S, v29.4S, v30.4S
+    __ fmla(v27, __ T2S, v28, v29);                    //	fmla	v27.2S, v28.2S, v29.2S
+    __ fmla(v1, __ T4S, v2, v3);                       //	fmla	v1.4S, v2.4S, v3.4S
+    __ fmla(v4, __ T2D, v5, v6);                       //	fmla	v4.2D, v5.2D, v6.2D
+    __ mlsv(v22, __ T4H, v23, v24);                    //	mls	v22.4H, v23.4H, v24.4H
+    __ mlsv(v12, __ T8H, v13, v14);                    //	mls	v12.8H, v13.8H, v14.8H
+    __ mlsv(v0, __ T2S, v1, v2);                       //	mls	v0.2S, v1.2S, v2.2S
+    __ mlsv(v24, __ T4S, v25, v26);                    //	mls	v24.4S, v25.4S, v26.4S
+    __ fmls(v13, __ T2S, v14, v15);                    //	fmls	v13.2S, v14.2S, v15.2S
+    __ fmls(v23, __ T4S, v24, v25);                    //	fmls	v23.4S, v24.4S, v25.4S
+    __ fmls(v27, __ T2D, v28, v29);                    //	fmls	v27.2D, v28.2D, v29.2D
+    __ fdiv(v12, __ T2S, v13, v14);                    //	fdiv	v12.2S, v13.2S, v14.2S
+    __ fdiv(v13, __ T4S, v14, v15);                    //	fdiv	v13.4S, v14.4S, v15.4S
+    __ fdiv(v29, __ T2D, v30, v31);                    //	fdiv	v29.2D, v30.2D, v31.2D
+    __ maxv(v3, __ T8B, v4, v5);                       //	smax	v3.8B, v4.8B, v5.8B
+    __ maxv(v22, __ T16B, v23, v24);                   //	smax	v22.16B, v23.16B, v24.16B
+    __ maxv(v14, __ T4H, v15, v16);                    //	smax	v14.4H, v15.4H, v16.4H
+    __ maxv(v19, __ T8H, v20, v21);                    //	smax	v19.8H, v20.8H, v21.8H
+    __ maxv(v14, __ T2S, v15, v16);                    //	smax	v14.2S, v15.2S, v16.2S
+    __ maxv(v5, __ T4S, v6, v7);                       //	smax	v5.4S, v6.4S, v7.4S
+    __ smaxp(v5, __ T8B, v6, v7);                      //	smaxp	v5.8B, v6.8B, v7.8B
+    __ smaxp(v10, __ T16B, v11, v12);                  //	smaxp	v10.16B, v11.16B, v12.16B
+    __ smaxp(v15, __ T4H, v16, v17);                   //	smaxp	v15.4H, v16.4H, v17.4H
+    __ smaxp(v13, __ T8H, v14, v15);                   //	smaxp	v13.8H, v14.8H, v15.8H
+    __ smaxp(v5, __ T2S, v6, v7);                      //	smaxp	v5.2S, v6.2S, v7.2S
+    __ smaxp(v17, __ T4S, v18, v19);                   //	smaxp	v17.4S, v18.4S, v19.4S
+    __ fmax(v29, __ T2S, v30, v31);                    //	fmax	v29.2S, v30.2S, v31.2S
+    __ fmax(v27, __ T4S, v28, v29);                    //	fmax	v27.4S, v28.4S, v29.4S
+    __ fmax(v9, __ T2D, v10, v11);                     //	fmax	v9.2D, v10.2D, v11.2D
+    __ minv(v24, __ T8B, v25, v26);                    //	smin	v24.8B, v25.8B, v26.8B
+    __ minv(v16, __ T16B, v17, v18);                   //	smin	v16.16B, v17.16B, v18.16B
+    __ minv(v3, __ T4H, v4, v5);                       //	smin	v3.4H, v4.4H, v5.4H
+    __ minv(v29, __ T8H, v30, v31);                    //	smin	v29.8H, v30.8H, v31.8H
+    __ minv(v11, __ T2S, v12, v13);                    //	smin	v11.2S, v12.2S, v13.2S
+    __ minv(v11, __ T4S, v12, v13);                    //	smin	v11.4S, v12.4S, v13.4S
+    __ sminp(v4, __ T8B, v5, v6);                      //	sminp	v4.8B, v5.8B, v6.8B
+    __ sminp(v20, __ T16B, v21, v22);                  //	sminp	v20.16B, v21.16B, v22.16B
+    __ sminp(v11, __ T4H, v12, v13);                   //	sminp	v11.4H, v12.4H, v13.4H
+    __ sminp(v24, __ T8H, v25, v26);                   //	sminp	v24.8H, v25.8H, v26.8H
+    __ sminp(v15, __ T2S, v16, v17);                   //	sminp	v15.2S, v16.2S, v17.2S
+    __ sminp(v20, __ T4S, v21, v22);                   //	sminp	v20.4S, v21.4S, v22.4S
+    __ fmin(v16, __ T2S, v17, v18);                    //	fmin	v16.2S, v17.2S, v18.2S
+    __ fmin(v24, __ T4S, v25, v26);                    //	fmin	v24.4S, v25.4S, v26.4S
+    __ fmin(v1, __ T2D, v2, v3);                       //	fmin	v1.2D, v2.2D, v3.2D
+    __ cmeq(v6, __ T8B, v7, v8);                       //	cmeq	v6.8B, v7.8B, v8.8B
+    __ cmeq(v28, __ T16B, v29, v30);                   //	cmeq	v28.16B, v29.16B, v30.16B
+    __ cmeq(v30, __ T4H, v31, v0);                     //	cmeq	v30.4H, v31.4H, v0.4H
+    __ cmeq(v8, __ T8H, v9, v10);                      //	cmeq	v8.8H, v9.8H, v10.8H
+    __ cmeq(v5, __ T2S, v6, v7);                       //	cmeq	v5.2S, v6.2S, v7.2S
+    __ cmeq(v23, __ T4S, v24, v25);                    //	cmeq	v23.4S, v24.4S, v25.4S
+    __ cmeq(v17, __ T2D, v18, v19);                    //	cmeq	v17.2D, v18.2D, v19.2D
+    __ fcmeq(v10, __ T2S, v11, v12);                   //	fcmeq	v10.2S, v11.2S, v12.2S
+    __ fcmeq(v9, __ T4S, v10, v11);                    //	fcmeq	v9.4S, v10.4S, v11.4S
+    __ fcmeq(v12, __ T2D, v13, v14);                   //	fcmeq	v12.2D, v13.2D, v14.2D
+    __ cmgt(v20, __ T8B, v21, v22);                    //	cmgt	v20.8B, v21.8B, v22.8B
+    __ cmgt(v1, __ T16B, v2, v3);                      //	cmgt	v1.16B, v2.16B, v3.16B
+    __ cmgt(v9, __ T4H, v10, v11);                     //	cmgt	v9.4H, v10.4H, v11.4H
+    __ cmgt(v17, __ T8H, v18, v19);                    //	cmgt	v17.8H, v18.8H, v19.8H
+    __ cmgt(v13, __ T2S, v14, v15);                    //	cmgt	v13.2S, v14.2S, v15.2S
+    __ cmgt(v1, __ T4S, v2, v3);                       //	cmgt	v1.4S, v2.4S, v3.4S
+    __ cmgt(v21, __ T2D, v22, v23);                    //	cmgt	v21.2D, v22.2D, v23.2D
+    __ cmhi(v13, __ T8B, v14, v15);                    //	cmhi	v13.8B, v14.8B, v15.8B
+    __ cmhi(v8, __ T16B, v9, v10);                     //	cmhi	v8.16B, v9.16B, v10.16B
+    __ cmhi(v12, __ T4H, v13, v14);                    //	cmhi	v12.4H, v13.4H, v14.4H
+    __ cmhi(v23, __ T8H, v24, v25);                    //	cmhi	v23.8H, v24.8H, v25.8H
+    __ cmhi(v6, __ T2S, v7, v8);                       //	cmhi	v6.2S, v7.2S, v8.2S
+    __ cmhi(v11, __ T4S, v12, v13);                    //	cmhi	v11.4S, v12.4S, v13.4S
+    __ cmhi(v4, __ T2D, v5, v6);                       //	cmhi	v4.2D, v5.2D, v6.2D
+    __ cmhs(v4, __ T8B, v5, v6);                       //	cmhs	v4.8B, v5.8B, v6.8B
+    __ cmhs(v3, __ T16B, v4, v5);                      //	cmhs	v3.16B, v4.16B, v5.16B
+    __ cmhs(v19, __ T4H, v20, v21);                    //	cmhs	v19.4H, v20.4H, v21.4H
+    __ cmhs(v11, __ T8H, v12, v13);                    //	cmhs	v11.8H, v12.8H, v13.8H
+    __ cmhs(v5, __ T2S, v6, v7);                       //	cmhs	v5.2S, v6.2S, v7.2S
+    __ cmhs(v0, __ T4S, v1, v2);                       //	cmhs	v0.4S, v1.4S, v2.4S
+    __ cmhs(v13, __ T2D, v14, v15);                    //	cmhs	v13.2D, v14.2D, v15.2D
+    __ fcmgt(v17, __ T2S, v18, v19);                   //	fcmgt	v17.2S, v18.2S, v19.2S
+    __ fcmgt(v12, __ T4S, v13, v14);                   //	fcmgt	v12.4S, v13.4S, v14.4S
+    __ fcmgt(v14, __ T2D, v15, v16);                   //	fcmgt	v14.2D, v15.2D, v16.2D
+    __ cmge(v2, __ T8B, v3, v4);                       //	cmge	v2.8B, v3.8B, v4.8B
+    __ cmge(v20, __ T16B, v21, v22);                   //	cmge	v20.16B, v21.16B, v22.16B
+    __ cmge(v22, __ T4H, v23, v24);                    //	cmge	v22.4H, v23.4H, v24.4H
+    __ cmge(v22, __ T8H, v23, v24);                    //	cmge	v22.8H, v23.8H, v24.8H
+    __ cmge(v21, __ T2S, v22, v23);                    //	cmge	v21.2S, v22.2S, v23.2S
+    __ cmge(v2, __ T4S, v3, v4);                       //	cmge	v2.4S, v3.4S, v4.4S
+    __ cmge(v24, __ T2D, v25, v26);                    //	cmge	v24.2D, v25.2D, v26.2D
+    __ fcmge(v13, __ T2S, v14, v15);                   //	fcmge	v13.2S, v14.2S, v15.2S
+    __ fcmge(v17, __ T4S, v18, v19);                   //	fcmge	v17.4S, v18.4S, v19.4S
+    __ fcmge(v23, __ T2D, v24, v25);                   //	fcmge	v23.2D, v24.2D, v25.2D
 
 // SpecialCases
-    __ ccmn(zr, zr, 3u, Assembler::LE);                //       ccmn    xzr, xzr, #3, LE
-    __ ccmnw(zr, zr, 5u, Assembler::EQ);               //       ccmn    wzr, wzr, #5, EQ
-    __ ccmp(zr, 1, 4u, Assembler::NE);                 //       ccmp    xzr, 1, #4, NE
-    __ ccmpw(zr, 2, 2, Assembler::GT);                 //       ccmp    wzr, 2, #2, GT
-    __ extr(zr, zr, zr, 0);                            //       extr    xzr, xzr, xzr, 0
-    __ stlxp(r0, zr, zr, sp);                          //       stlxp   w0, xzr, xzr, [sp]
-    __ stlxpw(r2, zr, zr, r3);                         //       stlxp   w2, wzr, wzr, [x3]
-    __ stxp(r4, zr, zr, r5);                           //       stxp    w4, xzr, xzr, [x5]
-    __ stxpw(r6, zr, zr, sp);                          //       stxp    w6, wzr, wzr, [sp]
-    __ dup(v0, __ T16B, zr);                           //       dup     v0.16b, wzr
-    __ mov(v1, __ T1D, 0, zr);                         //       mov     v1.d[0], xzr
-    __ mov(v1, __ T2S, 1, zr);                         //       mov     v1.s[1], wzr
-    __ mov(v1, __ T4H, 2, zr);                         //       mov     v1.h[2], wzr
-    __ mov(v1, __ T8B, 3, zr);                         //       mov     v1.b[3], wzr
-    __ smov(r0, v1, __ S, 0);                          //       smov    x0, v1.s[0]
-    __ smov(r0, v1, __ H, 1);                          //       smov    x0, v1.h[1]
-    __ smov(r0, v1, __ B, 2);                          //       smov    x0, v1.b[2]
-    __ umov(r0, v1, __ D, 0);                          //       umov    x0, v1.d[0]
-    __ umov(r0, v1, __ S, 1);                          //       umov    w0, v1.s[1]
-    __ umov(r0, v1, __ H, 2);                          //       umov    w0, v1.h[2]
-    __ umov(r0, v1, __ B, 3);                          //       umov    w0, v1.b[3]
-    __ ld1(v31, v0, __ T2D, Address(__ post(r1, r0))); //       ld1     {v31.2d, v0.2d}, [x1], x0
-    __ sve_cpy(z0, __ S, p0, v1);                      //       mov     z0.s, p0/m, s1
-    __ sve_inc(r0, __ S);                              //       incw    x0
-    __ sve_dec(r1, __ H);                              //       dech    x1
-    __ sve_lsl(z0, __ B, z1, 7);                       //       lsl     z0.b, z1.b, #7
-    __ sve_lsl(z21, __ H, z1, 15);                     //       lsl     z21.h, z1.h, #15
-    __ sve_lsl(z0, __ S, z1, 31);                      //       lsl     z0.s, z1.s, #31
-    __ sve_lsl(z0, __ D, z1, 63);                      //       lsl     z0.d, z1.d, #63
-    __ sve_lsr(z0, __ B, z1, 7);                       //       lsr     z0.b, z1.b, #7
-    __ sve_asr(z0, __ H, z11, 15);                     //       asr     z0.h, z11.h, #15
-    __ sve_lsr(z30, __ S, z1, 31);                     //       lsr     z30.s, z1.s, #31
-    __ sve_asr(z0, __ D, z1, 63);                      //       asr     z0.d, z1.d, #63
-    __ sve_addvl(sp, r0, 31);                          //       addvl   sp, x0, #31
-    __ sve_addpl(r1, sp, -32);                         //       addpl   x1, sp, -32
-    __ sve_cntp(r8, __ B, p0, p1);                     //       cntp    x8, p0, p1.b
-    __ sve_dup(z0, __ B, 127);                         //       dup     z0.b, 127
-    __ sve_dup(z1, __ H, -128);                        //       dup     z1.h, -128
-    __ sve_dup(z2, __ S, 32512);                       //       dup     z2.s, 32512
-    __ sve_dup(z7, __ D, -32768);                      //       dup     z7.d, -32768
-    __ sve_ld1b(z0, __ B, p0, Address(sp));            //       ld1b    {z0.b}, p0/z, [sp]
-    __ sve_ld1h(z10, __ H, p1, Address(sp, -8));       //       ld1h    {z10.h}, p1/z, [sp, #-8, MUL VL]
-    __ sve_ld1w(z20, __ S, p2, Address(r0, 7));        //       ld1w    {z20.s}, p2/z, [x0, #7, MUL VL]
-    __ sve_ld1b(z30, __ B, p3, Address(sp, r8));       //       ld1b    {z30.b}, p3/z, [sp, x8]
-    __ sve_ld1w(z0, __ S, p4, Address(sp, r28));       //       ld1w    {z0.s}, p4/z, [sp, x28, LSL #2]
-    __ sve_ld1d(z11, __ D, p5, Address(r0, r1));       //       ld1d    {z11.d}, p5/z, [x0, x1, LSL #3]
-    __ sve_st1b(z22, __ B, p6, Address(sp));           //       st1b    {z22.b}, p6, [sp]
-    __ sve_st1b(z31, __ B, p7, Address(sp, -8));       //       st1b    {z31.b}, p7, [sp, #-8, MUL VL]
-    __ sve_st1w(z0, __ S, p1, Address(r0, 7));         //       st1w    {z0.s}, p1, [x0, #7, MUL VL]
-    __ sve_st1b(z0, __ B, p2, Address(sp, r1));        //       st1b    {z0.b}, p2, [sp, x1]
-    __ sve_st1h(z0, __ H, p3, Address(sp, r8));        //       st1h    {z0.h}, p3, [sp, x8, LSL #1]
-    __ sve_st1d(z0, __ D, p4, Address(r0, r17));       //       st1d    {z0.d}, p4, [x0, x17, LSL #3]
-    __ sve_ldr(z0, Address(sp));                       //       ldr     z0, [sp]
-    __ sve_ldr(z31, Address(sp, -256));                //       ldr     z31, [sp, #-256, MUL VL]
-    __ sve_str(z8, Address(r8, 255));                  //       str     z8, [x8, #255, MUL VL]
+    __ ccmn(zr, zr, 3u, Assembler::LE);                //	ccmn	xzr, xzr, #3, LE
+    __ ccmnw(zr, zr, 5u, Assembler::EQ);               //	ccmn	wzr, wzr, #5, EQ
+    __ ccmp(zr, 1, 4u, Assembler::NE);                 //	ccmp	xzr, 1, #4, NE
+    __ ccmpw(zr, 2, 2, Assembler::GT);                 //	ccmp	wzr, 2, #2, GT
+    __ extr(zr, zr, zr, 0);                            //	extr	xzr, xzr, xzr, 0
+    __ stlxp(r0, zr, zr, sp);                          //	stlxp	w0, xzr, xzr, [sp]
+    __ stlxpw(r2, zr, zr, r3);                         //	stlxp	w2, wzr, wzr, [x3]
+    __ stxp(r4, zr, zr, r5);                           //	stxp	w4, xzr, xzr, [x5]
+    __ stxpw(r6, zr, zr, sp);                          //	stxp	w6, wzr, wzr, [sp]
+    __ dup(v0, __ T16B, zr);                           //	dup	v0.16b, wzr
+    __ mov(v1, __ T1D, 0, zr);                         //	mov	v1.d[0], xzr
+    __ mov(v1, __ T2S, 1, zr);                         //	mov	v1.s[1], wzr
+    __ mov(v1, __ T4H, 2, zr);                         //	mov	v1.h[2], wzr
+    __ mov(v1, __ T8B, 3, zr);                         //	mov	v1.b[3], wzr
+    __ smov(r0, v1, __ S, 0);                          //	smov	x0, v1.s[0]
+    __ smov(r0, v1, __ H, 1);                          //	smov	x0, v1.h[1]
+    __ smov(r0, v1, __ B, 2);                          //	smov	x0, v1.b[2]
+    __ umov(r0, v1, __ D, 0);                          //	umov	x0, v1.d[0]
+    __ umov(r0, v1, __ S, 1);                          //	umov	w0, v1.s[1]
+    __ umov(r0, v1, __ H, 2);                          //	umov	w0, v1.h[2]
+    __ umov(r0, v1, __ B, 3);                          //	umov	w0, v1.b[3]
+    __ ld1(v31, v0, __ T2D, Address(__ post(r1, r0))); //	ld1	{v31.2d, v0.2d}, [x1], x0
+    __ sve_cpy(z0, __ S, p0, v1);                      //	mov	z0.s, p0/m, s1
+    __ sve_inc(r0, __ S);                              //	incw	x0
+    __ sve_dec(r1, __ H);                              //	dech	x1
+    __ sve_lsl(z0, __ B, z1, 7);                       //	lsl	z0.b, z1.b, #7
+    __ sve_lsl(z21, __ H, z1, 15);                     //	lsl	z21.h, z1.h, #15
+    __ sve_lsl(z0, __ S, z1, 31);                      //	lsl	z0.s, z1.s, #31
+    __ sve_lsl(z0, __ D, z1, 63);                      //	lsl	z0.d, z1.d, #63
+    __ sve_lsr(z0, __ B, z1, 7);                       //	lsr	z0.b, z1.b, #7
+    __ sve_asr(z0, __ H, z11, 15);                     //	asr	z0.h, z11.h, #15
+    __ sve_lsr(z30, __ S, z1, 31);                     //	lsr	z30.s, z1.s, #31
+    __ sve_asr(z0, __ D, z1, 63);                      //	asr	z0.d, z1.d, #63
+    __ sve_addvl(sp, r0, 31);                          //	addvl	sp, x0, #31
+    __ sve_addpl(r1, sp, -32);                         //	addpl	x1, sp, -32
+    __ sve_cntp(r8, __ B, p0, p1);                     //	cntp	x8, p0, p1.b
+    __ sve_dup(z0, __ B, 127);                         //	dup	z0.b, 127
+    __ sve_dup(z1, __ H, -128);                        //	dup	z1.h, -128
+    __ sve_dup(z2, __ S, 32512);                       //	dup	z2.s, 32512
+    __ sve_dup(z7, __ D, -32768);                      //	dup	z7.d, -32768
+    __ sve_ld1b(z0, __ B, p0, Address(sp));            //	ld1b	{z0.b}, p0/z, [sp]
+    __ sve_ld1h(z10, __ H, p1, Address(sp, -8));       //	ld1h	{z10.h}, p1/z, [sp, #-8, MUL VL]
+    __ sve_ld1w(z20, __ S, p2, Address(r0, 7));        //	ld1w	{z20.s}, p2/z, [x0, #7, MUL VL]
+    __ sve_ld1b(z30, __ B, p3, Address(sp, r8));       //	ld1b	{z30.b}, p3/z, [sp, x8]
+    __ sve_ld1w(z0, __ S, p4, Address(sp, r28));       //	ld1w	{z0.s}, p4/z, [sp, x28, LSL #2]
+    __ sve_ld1d(z11, __ D, p5, Address(r0, r1));       //	ld1d	{z11.d}, p5/z, [x0, x1, LSL #3]
+    __ sve_st1b(z22, __ B, p6, Address(sp));           //	st1b	{z22.b}, p6, [sp]
+    __ sve_st1b(z31, __ B, p7, Address(sp, -8));       //	st1b	{z31.b}, p7, [sp, #-8, MUL VL]
+    __ sve_st1w(z0, __ S, p1, Address(r0, 7));         //	st1w	{z0.s}, p1, [x0, #7, MUL VL]
+    __ sve_st1b(z0, __ B, p2, Address(sp, r1));        //	st1b	{z0.b}, p2, [sp, x1]
+    __ sve_st1h(z0, __ H, p3, Address(sp, r8));        //	st1h	{z0.h}, p3, [sp, x8, LSL #1]
+    __ sve_st1d(z0, __ D, p4, Address(r0, r17));       //	st1d	{z0.d}, p4, [x0, x17, LSL #3]
+    __ sve_ldr(z0, Address(sp));                       //	ldr	z0, [sp]
+    __ sve_ldr(z31, Address(sp, -256));                //	ldr	z31, [sp, #-256, MUL VL]
+    __ sve_str(z8, Address(r8, 255));                  //	str	z8, [x8, #255, MUL VL]
 
 // FloatImmediateOp
-    __ fmovd(v0, 2.0);                                 //       fmov d0, #2.0
-    __ fmovd(v0, 2.125);                               //       fmov d0, #2.125
-    __ fmovd(v0, 4.0);                                 //       fmov d0, #4.0
-    __ fmovd(v0, 4.25);                                //       fmov d0, #4.25
-    __ fmovd(v0, 8.0);                                 //       fmov d0, #8.0
-    __ fmovd(v0, 8.5);                                 //       fmov d0, #8.5
-    __ fmovd(v0, 16.0);                                //       fmov d0, #16.0
-    __ fmovd(v0, 17.0);                                //       fmov d0, #17.0
-    __ fmovd(v0, 0.125);                               //       fmov d0, #0.125
-    __ fmovd(v0, 0.1328125);                           //       fmov d0, #0.1328125
-    __ fmovd(v0, 0.25);                                //       fmov d0, #0.25
-    __ fmovd(v0, 0.265625);                            //       fmov d0, #0.265625
-    __ fmovd(v0, 0.5);                                 //       fmov d0, #0.5
-    __ fmovd(v0, 0.53125);                             //       fmov d0, #0.53125
-    __ fmovd(v0, 1.0);                                 //       fmov d0, #1.0
-    __ fmovd(v0, 1.0625);                              //       fmov d0, #1.0625
-    __ fmovd(v0, -2.0);                                //       fmov d0, #-2.0
-    __ fmovd(v0, -2.125);                              //       fmov d0, #-2.125
-    __ fmovd(v0, -4.0);                                //       fmov d0, #-4.0
-    __ fmovd(v0, -4.25);                               //       fmov d0, #-4.25
-    __ fmovd(v0, -8.0);                                //       fmov d0, #-8.0
-    __ fmovd(v0, -8.5);                                //       fmov d0, #-8.5
-    __ fmovd(v0, -16.0);                               //       fmov d0, #-16.0
-    __ fmovd(v0, -17.0);                               //       fmov d0, #-17.0
-    __ fmovd(v0, -0.125);                              //       fmov d0, #-0.125
-    __ fmovd(v0, -0.1328125);                          //       fmov d0, #-0.1328125
-    __ fmovd(v0, -0.25);                               //       fmov d0, #-0.25
-    __ fmovd(v0, -0.265625);                           //       fmov d0, #-0.265625
-    __ fmovd(v0, -0.5);                                //       fmov d0, #-0.5
-    __ fmovd(v0, -0.53125);                            //       fmov d0, #-0.53125
-    __ fmovd(v0, -1.0);                                //       fmov d0, #-1.0
-    __ fmovd(v0, -1.0625);                             //       fmov d0, #-1.0625
+    __ fmovd(v0, 2.0);                                 //	fmov d0, #2.0
+    __ fmovd(v0, 2.125);                               //	fmov d0, #2.125
+    __ fmovd(v0, 4.0);                                 //	fmov d0, #4.0
+    __ fmovd(v0, 4.25);                                //	fmov d0, #4.25
+    __ fmovd(v0, 8.0);                                 //	fmov d0, #8.0
+    __ fmovd(v0, 8.5);                                 //	fmov d0, #8.5
+    __ fmovd(v0, 16.0);                                //	fmov d0, #16.0
+    __ fmovd(v0, 17.0);                                //	fmov d0, #17.0
+    __ fmovd(v0, 0.125);                               //	fmov d0, #0.125
+    __ fmovd(v0, 0.1328125);                           //	fmov d0, #0.1328125
+    __ fmovd(v0, 0.25);                                //	fmov d0, #0.25
+    __ fmovd(v0, 0.265625);                            //	fmov d0, #0.265625
+    __ fmovd(v0, 0.5);                                 //	fmov d0, #0.5
+    __ fmovd(v0, 0.53125);                             //	fmov d0, #0.53125
+    __ fmovd(v0, 1.0);                                 //	fmov d0, #1.0
+    __ fmovd(v0, 1.0625);                              //	fmov d0, #1.0625
+    __ fmovd(v0, -2.0);                                //	fmov d0, #-2.0
+    __ fmovd(v0, -2.125);                              //	fmov d0, #-2.125
+    __ fmovd(v0, -4.0);                                //	fmov d0, #-4.0
+    __ fmovd(v0, -4.25);                               //	fmov d0, #-4.25
+    __ fmovd(v0, -8.0);                                //	fmov d0, #-8.0
+    __ fmovd(v0, -8.5);                                //	fmov d0, #-8.5
+    __ fmovd(v0, -16.0);                               //	fmov d0, #-16.0
+    __ fmovd(v0, -17.0);                               //	fmov d0, #-17.0
+    __ fmovd(v0, -0.125);                              //	fmov d0, #-0.125
+    __ fmovd(v0, -0.1328125);                          //	fmov d0, #-0.1328125
+    __ fmovd(v0, -0.25);                               //	fmov d0, #-0.25
+    __ fmovd(v0, -0.265625);                           //	fmov d0, #-0.265625
+    __ fmovd(v0, -0.5);                                //	fmov d0, #-0.5
+    __ fmovd(v0, -0.53125);                            //	fmov d0, #-0.53125
+    __ fmovd(v0, -1.0);                                //	fmov d0, #-1.0
+    __ fmovd(v0, -1.0625);                             //	fmov d0, #-1.0625
 
 // LSEOp
-    __ swp(Assembler::xword, r0, r19, r12);            //       swp     x0, x19, [x12]
-    __ ldadd(Assembler::xword, r17, r22, r13);         //       ldadd   x17, x22, [x13]
-    __ ldbic(Assembler::xword, r28, r30, sp);          //       ldclr   x28, x30, [sp]
-    __ ldeor(Assembler::xword, r1, r26, r28);          //       ldeor   x1, x26, [x28]
-    __ ldorr(Assembler::xword, r4, r30, r4);           //       ldset   x4, x30, [x4]
-    __ ldsmin(Assembler::xword, r6, r30, r26);         //       ldsmin  x6, x30, [x26]
-    __ ldsmax(Assembler::xword, r16, r9, r8);          //       ldsmax  x16, x9, [x8]
-    __ ldumin(Assembler::xword, r12, r0, r20);         //       ldumin  x12, x0, [x20]
-    __ ldumax(Assembler::xword, r1, r24, r2);          //       ldumax  x1, x24, [x2]
+    __ swp(Assembler::xword, r8, r10, r9);             //	swp	x8, x10, [x9]
+    __ ldadd(Assembler::xword, r13, r10, r14);         //	ldadd	x13, x10, [x14]
+    __ ldbic(Assembler::xword, r1, r8, sp);            //	ldclr	x1, x8, [sp]
+    __ ldeor(Assembler::xword, r22, r16, r21);         //	ldeor	x22, x16, [x21]
+    __ ldorr(Assembler::xword, r7, r26, r16);          //	ldset	x7, x26, [x16]
+    __ ldsmin(Assembler::xword, r10, r21, r21);        //	ldsmin	x10, x21, [x21]
+    __ ldsmax(Assembler::xword, r9, r24, r19);         //	ldsmax	x9, x24, [x19]
+    __ ldumin(Assembler::xword, r15, r24, r22);        //	ldumin	x15, x24, [x22]
+    __ ldumax(Assembler::xword, r24, r30, r19);        //	ldumax	x24, x30, [x19]
 
 // LSEOp
-    __ swpa(Assembler::xword, r0, r9, r24);            //       swpa    x0, x9, [x24]
-    __ ldadda(Assembler::xword, r26, r16, r30);        //       ldadda  x26, x16, [x30]
-    __ ldbica(Assembler::xword, r3, r10, r23);         //       ldclra  x3, x10, [x23]
-    __ ldeora(Assembler::xword, r10, r4, r15);         //       ldeora  x10, x4, [x15]
-    __ ldorra(Assembler::xword, r2, r11, r8);          //       ldseta  x2, x11, [x8]
-    __ ldsmina(Assembler::xword, r10, r15, r17);       //       ldsmina x10, x15, [x17]
-    __ ldsmaxa(Assembler::xword, r2, r10, r12);        //       ldsmaxa x2, x10, [x12]
-    __ ldumina(Assembler::xword, r12, r15, r13);       //       ldumina x12, x15, [x13]
-    __ ldumaxa(Assembler::xword, r2, r7, r20);         //       ldumaxa x2, x7, [x20]
+    __ swpa(Assembler::xword, r26, r26, r6);           //	swpa	x26, x26, [x6]
+    __ ldadda(Assembler::xword, r9, r9, r0);           //	ldadda	x9, x9, [x0]
+    __ ldbica(Assembler::xword, r6, r13, r7);          //	ldclra	x6, x13, [x7]
+    __ ldeora(Assembler::xword, r17, r10, r24);        //	ldeora	x17, x10, [x24]
+    __ ldorra(Assembler::xword, r5, r2, r0);           //	ldseta	x5, x2, [x0]
+    __ ldsmina(Assembler::xword, r7, r23, r30);        //	ldsmina	x7, x23, [x30]
+    __ ldsmaxa(Assembler::xword, r20, r6, r28);        //	ldsmaxa	x20, x6, [x28]
+    __ ldumina(Assembler::xword, r23, r16, sp);        //	ldumina	x23, x16, [sp]
+    __ ldumaxa(Assembler::xword, r14, r10, r4);        //	ldumaxa	x14, x10, [x4]
 
 // LSEOp
-    __ swpal(Assembler::xword, r26, r16, r4);          //       swpal   x26, x16, [x4]
-    __ ldaddal(Assembler::xword, r2, r4, r12);         //       ldaddal x2, x4, [x12]
-    __ ldbical(Assembler::xword, r16, r21, r16);       //       ldclral x16, x21, [x16]
-    __ ldeoral(Assembler::xword, r16, r11, r21);       //       ldeoral x16, x11, [x21]
-    __ ldorral(Assembler::xword, r23, r12, r26);       //       ldsetal x23, x12, [x26]
-    __ ldsminal(Assembler::xword, r23, r28, r14);      //       ldsminal        x23, x28, [x14]
-    __ ldsmaxal(Assembler::xword, r11, r24, r1);       //       ldsmaxal        x11, x24, [x1]
-    __ lduminal(Assembler::xword, r12, zr, r10);       //       lduminal        x12, xzr, [x10]
-    __ ldumaxal(Assembler::xword, r16, r7, r2);        //       ldumaxal        x16, x7, [x2]
+    __ swpal(Assembler::xword, r10, r1, r10);          //	swpal	x10, x1, [x10]
+    __ ldaddal(Assembler::xword, r26, r13, r28);       //	ldaddal	x26, x13, [x28]
+    __ ldbical(Assembler::xword, r25, r16, r1);        //	ldclral	x25, x16, [x1]
+    __ ldeoral(Assembler::xword, r8, r24, r10);        //	ldeoral	x8, x24, [x10]
+    __ ldorral(Assembler::xword, r28, r3, r24);        //	ldsetal	x28, x3, [x24]
+    __ ldsminal(Assembler::xword, r5, r25, r21);       //	ldsminal	x5, x25, [x21]
+    __ ldsmaxal(Assembler::xword, r14, r29, r2);       //	ldsmaxal	x14, x29, [x2]
+    __ lduminal(Assembler::xword, r30, r6, r17);       //	lduminal	x30, x6, [x17]
+    __ ldumaxal(Assembler::xword, zr, r25, r30);       //	ldumaxal	xzr, x25, [x30]
 
 // LSEOp
-    __ swpl(Assembler::xword, r3, r13, r19);           //       swpl    x3, x13, [x19]
-    __ ldaddl(Assembler::xword, r17, r16, r3);         //       ldaddl  x17, x16, [x3]
-    __ ldbicl(Assembler::xword, r1, r11, r30);         //       ldclrl  x1, x11, [x30]
-    __ ldeorl(Assembler::xword, r5, r8, r15);          //       ldeorl  x5, x8, [x15]
-    __ ldorrl(Assembler::xword, r29, r30, r0);         //       ldsetl  x29, x30, [x0]
-    __ ldsminl(Assembler::xword, r20, r7, r20);        //       ldsminl x20, x7, [x20]
-    __ ldsmaxl(Assembler::xword, r23, r28, r21);       //       ldsmaxl x23, x28, [x21]
-    __ lduminl(Assembler::xword, r27, r25, r5);        //       lduminl x27, x25, [x5]
-    __ ldumaxl(Assembler::xword, r1, r23, r16);        //       ldumaxl x1, x23, [x16]
+    __ swpl(Assembler::xword, r16, r11, r14);          //	swpl	x16, x11, [x14]
+    __ ldaddl(Assembler::xword, r23, r10, r19);        //	ldaddl	x23, x10, [x19]
+    __ ldbicl(Assembler::xword, r9, r29, r4);          //	ldclrl	x9, x29, [x4]
+    __ ldeorl(Assembler::xword, r4, r30, r25);         //	ldeorl	x4, x30, [x25]
+    __ ldorrl(Assembler::xword, r26, r5, r16);         //	ldsetl	x26, x5, [x16]
+    __ ldsminl(Assembler::xword, r30, r14, r7);        //	ldsminl	x30, x14, [x7]
+    __ ldsmaxl(Assembler::xword, r16, r9, r23);        //	ldsmaxl	x16, x9, [x23]
+    __ lduminl(Assembler::xword, r6, r8, r3);          //	lduminl	x6, x8, [x3]
+    __ ldumaxl(Assembler::xword, r8, r12, r0);         //	ldumaxl	x8, x12, [x0]
 
 // LSEOp
-    __ swp(Assembler::word, zr, r5, r12);              //       swp     wzr, w5, [x12]
-    __ ldadd(Assembler::word, r9, r28, r15);           //       ldadd   w9, w28, [x15]
-    __ ldbic(Assembler::word, r29, r22, sp);           //       ldclr   w29, w22, [sp]
-    __ ldeor(Assembler::word, r19, zr, r5);            //       ldeor   w19, wzr, [x5]
-    __ ldorr(Assembler::word, r14, r16, sp);           //       ldset   w14, w16, [sp]
-    __ ldsmin(Assembler::word, r16, r27, r20);         //       ldsmin  w16, w27, [x20]
-    __ ldsmax(Assembler::word, r16, r12, r11);         //       ldsmax  w16, w12, [x11]
-    __ ldumin(Assembler::word, r9, r6, r30);           //       ldumin  w9, w6, [x30]
-    __ ldumax(Assembler::word, r17, r27, r28);         //       ldumax  w17, w27, [x28]
+    __ swp(Assembler::word, r2, r25, sp);              //	swp	w2, w25, [sp]
+    __ ldadd(Assembler::word, r6, r30, r22);           //	ldadd	w6, w30, [x22]
+    __ ldbic(Assembler::word, r21, r6, r0);            //	ldclr	w21, w6, [x0]
+    __ ldeor(Assembler::word, r15, r14, sp);           //	ldeor	w15, w14, [sp]
+    __ ldorr(Assembler::word, r19, r17, r14);          //	ldset	w19, w17, [x14]
+    __ ldsmin(Assembler::word, r0, zr, r22);           //	ldsmin	w0, wzr, [x22]
+    __ ldsmax(Assembler::word, r21, r5, r4);           //	ldsmax	w21, w5, [x4]
+    __ ldumin(Assembler::word, r19, r27, r14);         //	ldumin	w19, w27, [x14]
+    __ ldumax(Assembler::word, r23, r24, r9);          //	ldumax	w23, w24, [x9]
 
 // LSEOp
-    __ swpa(Assembler::word, r30, r7, r10);            //       swpa    w30, w7, [x10]
-    __ ldadda(Assembler::word, r20, r10, r4);          //       ldadda  w20, w10, [x4]
-    __ ldbica(Assembler::word, r24, r17, r17);         //       ldclra  w24, w17, [x17]
-    __ ldeora(Assembler::word, r22, r3, r29);          //       ldeora  w22, w3, [x29]
-    __ ldorra(Assembler::word, r15, r22, r19);         //       ldseta  w15, w22, [x19]
-    __ ldsmina(Assembler::word, r19, r22, r2);         //       ldsmina w19, w22, [x2]
-    __ ldsmaxa(Assembler::word, r15, r6, r12);         //       ldsmaxa w15, w6, [x12]
-    __ ldumina(Assembler::word, r16, r11, r13);        //       ldumina w16, w11, [x13]
-    __ ldumaxa(Assembler::word, r23, r1, r30);         //       ldumaxa w23, w1, [x30]
+    __ swpa(Assembler::word, r14, r16, r12);           //	swpa	w14, w16, [x12]
+    __ ldadda(Assembler::word, r30, r22, r15);         //	ldadda	w30, w22, [x15]
+    __ ldbica(Assembler::word, r24, r8, r7);           //	ldclra	w24, w8, [x7]
+    __ ldeora(Assembler::word, r25, r22, r30);         //	ldeora	w25, w22, [x30]
+    __ ldorra(Assembler::word, r14, r23, r22);         //	ldseta	w14, w23, [x22]
+    __ ldsmina(Assembler::word, r27, r17, r22);        //	ldsmina	w27, w17, [x22]
+    __ ldsmaxa(Assembler::word, r25, r16, r6);         //	ldsmaxa	w25, w16, [x6]
+    __ ldumina(Assembler::word, r30, r16, r7);         //	ldumina	w30, w16, [x7]
+    __ ldumaxa(Assembler::word, r28, r9, r22);         //	ldumaxa	w28, w9, [x22]
 
 // LSEOp
-    __ swpal(Assembler::word, r19, r5, r17);           //       swpal   w19, w5, [x17]
-    __ ldaddal(Assembler::word, r2, r16, r22);         //       ldaddal w2, w16, [x22]
-    __ ldbical(Assembler::word, r13, r10, r21);        //       ldclral w13, w10, [x21]
-    __ ldeoral(Assembler::word, r29, r27, r12);        //       ldeoral w29, w27, [x12]
-    __ ldorral(Assembler::word, r27, r3, r1);          //       ldsetal w27, w3, [x1]
-    __ ldsminal(Assembler::word, zr, r24, r19);        //       ldsminal        wzr, w24, [x19]
-    __ ldsmaxal(Assembler::word, r17, r9, r28);        //       ldsmaxal        w17, w9, [x28]
-    __ lduminal(Assembler::word, r27, r15, r7);        //       lduminal        w27, w15, [x7]
-    __ ldumaxal(Assembler::word, r21, r23, sp);        //       ldumaxal        w21, w23, [sp]
+    __ swpal(Assembler::word, r15, r11, r21);          //	swpal	w15, w11, [x21]
+    __ ldaddal(Assembler::word, zr, r14, r7);          //	ldaddal	wzr, w14, [x7]
+    __ ldbical(Assembler::word, r24, r24, r29);        //	ldclral	w24, w24, [x29]
+    __ ldeoral(Assembler::word, r29, r14, r25);        //	ldeoral	w29, w14, [x25]
+    __ ldorral(Assembler::word, r19, zr, r14);         //	ldsetal	w19, wzr, [x14]
+    __ ldsminal(Assembler::word, r20, r0, r5);         //	ldsminal	w20, w0, [x5]
+    __ ldsmaxal(Assembler::word, r30, r20, r25);       //	ldsmaxal	w30, w20, [x25]
+    __ lduminal(Assembler::word, r14, r27, r3);        //	lduminal	w14, w27, [x3]
+    __ ldumaxal(Assembler::word, r2, r26, r5);         //	ldumaxal	w2, w26, [x5]
 
 // LSEOp
-    __ swpl(Assembler::word, r25, r2, sp);             //       swpl    w25, w2, [sp]
-    __ ldaddl(Assembler::word, r27, r16, r10);         //       ldaddl  w27, w16, [x10]
-    __ ldbicl(Assembler::word, r23, r19, r3);          //       ldclrl  w23, w19, [x3]
-    __ ldeorl(Assembler::word, r16, r0, r25);          //       ldeorl  w16, w0, [x25]
-    __ ldorrl(Assembler::word, r26, r23, r2);          //       ldsetl  w26, w23, [x2]
-    __ ldsminl(Assembler::word, r16, r12, r4);         //       ldsminl w16, w12, [x4]
-    __ ldsmaxl(Assembler::word, r28, r30, r29);        //       ldsmaxl w28, w30, [x29]
-    __ lduminl(Assembler::word, r16, r27, r6);         //       lduminl w16, w27, [x6]
-    __ ldumaxl(Assembler::word, r9, r29, r15);         //       ldumaxl w9, w29, [x15]
+    __ swpl(Assembler::word, r16, r12, r20);           //	swpl	w16, w12, [x20]
+    __ ldaddl(Assembler::word, r11, r7, r11);          //	ldaddl	w11, w7, [x11]
+    __ ldbicl(Assembler::word, r23, r1, r14);          //	ldclrl	w23, w1, [x14]
+    __ ldeorl(Assembler::word, r2, r0, r24);           //	ldeorl	w2, w0, [x24]
+    __ ldorrl(Assembler::word, r0, r8, r7);            //	ldsetl	w0, w8, [x7]
+    __ ldsminl(Assembler::word, r12, r5, r29);         //	ldsminl	w12, w5, [x29]
+    __ ldsmaxl(Assembler::word, r12, r0, r26);         //	ldsmaxl	w12, w0, [x26]
+    __ lduminl(Assembler::word, r4, r11, r14);         //	lduminl	w4, w11, [x14]
+    __ ldumaxl(Assembler::word, r14, r26, r24);        //	ldumaxl	w14, w26, [x24]
 
 // SHA3SIMDOp
-    __ bcax(v7, __ T16B, v4, v7, v15);                 //       bcax            v7.16B, v4.16B, v7.16B, v15.16B
-    __ eor3(v9, __ T16B, v22, v8, v2);                 //       eor3            v9.16B, v22.16B, v8.16B, v2.16B
-    __ rax1(v27, __ T2D, v20, v30);                    //       rax1            v27.2D, v20.2D, v30.2D
-    __ xar(v5, __ T2D, v26, v0, 34);                   //       xar             v5.2D, v26.2D, v0.2D, #34
+    __ bcax(v15, __ T16B, v25, v0, v13);               //	bcax		v15.16B, v25.16B, v0.16B, v13.16B
+    __ eor3(v6, __ T16B, v12, v24, v1);                //	eor3		v6.16B, v12.16B, v24.16B, v1.16B
+    __ rax1(v19, __ T2D, v30, v8);                     //	rax1		v19.2D, v30.2D, v8.2D
+    __ xar(v0, __ T2D, v17, v11, 47);                  //	xar		v0.2D, v17.2D, v11.2D, #47
 
 // SHA512SIMDOp
-    __ sha512h(v14, __ T2D, v3, v25);                  //       sha512h         q14, q3, v25.2D
-    __ sha512h2(v8, __ T2D, v27, v21);                 //       sha512h2                q8, q27, v21.2D
-    __ sha512su0(v26, __ T2D, v26);                    //       sha512su0               v26.2D, v26.2D
-    __ sha512su1(v24, __ T2D, v22, v0);                //       sha512su1               v24.2D, v22.2D, v0.2D
+    __ sha512h(v26, __ T2D, v10, v21);                 //	sha512h		q26, q10, v21.2D
+    __ sha512h2(v14, __ T2D, v20, v4);                 //	sha512h2		q14, q20, v4.2D
+    __ sha512su0(v19, __ T2D, v16);                    //	sha512su0		v19.2D, v16.2D
+    __ sha512su1(v2, __ T2D, v8, v30);                 //	sha512su1		v2.2D, v8.2D, v30.2D
 
 // SVEVectorOp
-    __ sve_add(z4, __ B, z6, z17);                     //       add     z4.b, z6.b, z17.b
-    __ sve_sub(z3, __ H, z15, z1);                     //       sub     z3.h, z15.h, z1.h
-    __ sve_fadd(z6, __ D, z5, z9);                     //       fadd    z6.d, z5.d, z9.d
-    __ sve_fmul(z7, __ D, z20, z22);                   //       fmul    z7.d, z20.d, z22.d
-    __ sve_fsub(z5, __ D, z10, z8);                    //       fsub    z5.d, z10.d, z8.d
-    __ sve_abs(z30, __ B, p1, z17);                    //       abs     z30.b, p1/m, z17.b
-    __ sve_add(z11, __ B, p7, z28);                    //       add     z11.b, p7/m, z11.b, z28.b
-    __ sve_asr(z26, __ H, p5, z28);                    //       asr     z26.h, p5/m, z26.h, z28.h
-    __ sve_cnt(z13, __ D, p7, z16);                    //       cnt     z13.d, p7/m, z16.d
-    __ sve_lsl(z5, __ H, p0, z13);                     //       lsl     z5.h, p0/m, z5.h, z13.h
-    __ sve_lsr(z15, __ S, p2, z26);                    //       lsr     z15.s, p2/m, z15.s, z26.s
-    __ sve_mul(z11, __ S, p1, z22);                    //       mul     z11.s, p1/m, z11.s, z22.s
-    __ sve_neg(z4, __ S, p0, z19);                     //       neg     z4.s, p0/m, z19.s
-    __ sve_not(z17, __ H, p3, z14);                    //       not     z17.h, p3/m, z14.h
-    __ sve_smax(z2, __ S, p4, z3);                     //       smax    z2.s, p4/m, z2.s, z3.s
-    __ sve_smin(z23, __ B, p1, z6);                    //       smin    z23.b, p1/m, z23.b, z6.b
-    __ sve_sub(z17, __ S, p3, z27);                    //       sub     z17.s, p3/m, z17.s, z27.s
-    __ sve_fabs(z16, __ D, p1, z2);                    //       fabs    z16.d, p1/m, z2.d
-    __ sve_fadd(z3, __ D, p1, z6);                     //       fadd    z3.d, p1/m, z3.d, z6.d
-    __ sve_fdiv(z19, __ D, p3, z12);                   //       fdiv    z19.d, p3/m, z19.d, z12.d
-    __ sve_fmax(z8, __ D, p6, z19);                    //       fmax    z8.d, p6/m, z8.d, z19.d
-    __ sve_fmin(z0, __ S, p2, z23);                    //       fmin    z0.s, p2/m, z0.s, z23.s
-    __ sve_fmul(z19, __ D, p7, z13);                   //       fmul    z19.d, p7/m, z19.d, z13.d
-    __ sve_fneg(z6, __ S, p0, z7);                     //       fneg    z6.s, p0/m, z7.s
-    __ sve_frintm(z17, __ S, p6, z8);                  //       frintm  z17.s, p6/m, z8.s
-    __ sve_frintn(z22, __ D, p5, z22);                 //       frintn  z22.d, p5/m, z22.d
-    __ sve_frintp(z2, __ D, p0, z15);                  //       frintp  z2.d, p0/m, z15.d
-    __ sve_fsqrt(z20, __ D, p1, z4);                   //       fsqrt   z20.d, p1/m, z4.d
-    __ sve_fsub(z7, __ D, p0, z8);                     //       fsub    z7.d, p0/m, z7.d, z8.d
-    __ sve_fmla(z19, __ S, p5, z4, z15);               //       fmla    z19.s, p5/m, z4.s, z15.s
-    __ sve_fmls(z22, __ D, p2, z25, z5);               //       fmls    z22.d, p2/m, z25.d, z5.d
-    __ sve_fnmla(z16, __ S, p3, z22, z11);             //       fnmla   z16.s, p3/m, z22.s, z11.s
-    __ sve_fnmls(z13, __ D, p2, z20, z16);             //       fnmls   z13.d, p2/m, z20.d, z16.d
-    __ sve_mla(z15, __ H, p1, z4, z17);                //       mla     z15.h, p1/m, z4.h, z17.h
-    __ sve_mls(z6, __ S, p7, z4, z28);                 //       mls     z6.s, p7/m, z4.s, z28.s
-    __ sve_and(z29, z26, z9);                          //       and     z29.d, z26.d, z9.d
-    __ sve_eor(z2, z11, z28);                          //       eor     z2.d, z11.d, z28.d
-    __ sve_orr(z7, z1, z26);                           //       orr     z7.d, z1.d, z26.d
-    __ sve_bic(z17, z14, z8);                          //       bic     z17.d, z14.d, z8.d
+    __ sve_add(z3, __ S, z22, z3);                     //	add	z3.s, z22.s, z3.s
+    __ sve_sub(z0, __ H, z22, z4);                     //	sub	z0.h, z22.h, z4.h
+    __ sve_fadd(z12, __ D, z6, z17);                   //	fadd	z12.d, z6.d, z17.d
+    __ sve_fmul(z6, __ S, z13, z16);                   //	fmul	z6.s, z13.s, z16.s
+    __ sve_fsub(z17, __ D, z3, z22);                   //	fsub	z17.d, z3.d, z22.d
+    __ sve_abs(z3, __ H, p7, z15);                     //	abs	z3.h, p7/m, z15.h
+    __ sve_add(z14, __ D, p5, z4);                     //	add	z14.d, p5/m, z14.d, z4.d
+    __ sve_asr(z8, __ S, p6, z2);                      //	asr	z8.s, p6/m, z8.s, z2.s
+    __ sve_cnt(z26, __ H, p3, z14);                    //	cnt	z26.h, p3/m, z14.h
+    __ sve_lsl(z11, __ D, p7, z24);                    //	lsl	z11.d, p7/m, z11.d, z24.d
+    __ sve_lsr(z0, __ B, p7, z23);                     //	lsr	z0.b, p7/m, z0.b, z23.b
+    __ sve_mul(z17, __ D, p6, z30);                    //	mul	z17.d, p6/m, z17.d, z30.d
+    __ sve_neg(z7, __ S, p6, z7);                      //	neg	z7.s, p6/m, z7.s
+    __ sve_not(z15, __ H, p7, z4);                     //	not	z15.h, p7/m, z4.h
+    __ sve_smax(z14, __ D, p4, z11);                   //	smax	z14.d, p4/m, z14.d, z11.d
+    __ sve_smin(z19, __ B, p2, z26);                   //	smin	z19.b, p2/m, z19.b, z26.b
+    __ sve_sub(z6, __ B, p4, z29);                     //	sub	z6.b, p4/m, z6.b, z29.b
+    __ sve_fabs(z30, __ D, p0, z4);                    //	fabs	z30.d, p0/m, z4.d
+    __ sve_fadd(z1, __ S, p5, z27);                    //	fadd	z1.s, p5/m, z1.s, z27.s
+    __ sve_fdiv(z24, __ S, p7, z12);                   //	fdiv	z24.s, p7/m, z24.s, z12.s
+    __ sve_fmax(z13, __ S, p7, z6);                    //	fmax	z13.s, p7/m, z13.s, z6.s
+    __ sve_fmin(z12, __ D, p0, z25);                   //	fmin	z12.d, p0/m, z12.d, z25.d
+    __ sve_fmul(z28, __ D, p3, z23);                   //	fmul	z28.d, p3/m, z28.d, z23.d
+    __ sve_fneg(z5, __ D, p6, z4);                     //	fneg	z5.d, p6/m, z4.d
+    __ sve_frintm(z28, __ D, p3, z19);                 //	frintm	z28.d, p3/m, z19.d
+    __ sve_frintn(z1, __ D, p3, z15);                  //	frintn	z1.d, p3/m, z15.d
+    __ sve_frintp(z17, __ S, p3, z0);                  //	frintp	z17.s, p3/m, z0.s
+    __ sve_fsqrt(z1, __ D, p2, z7);                    //	fsqrt	z1.d, p2/m, z7.d
+    __ sve_fsub(z27, __ S, p3, z21);                   //	fsub	z27.s, p3/m, z27.s, z21.s
+    __ sve_fmla(z27, __ D, p6, z29, z20);              //	fmla	z27.d, p6/m, z29.d, z20.d
+    __ sve_fmls(z28, __ S, p5, z15, z21);              //	fmls	z28.s, p5/m, z15.s, z21.s
+    __ sve_fnmla(z5, __ D, p5, z17, z26);              //	fnmla	z5.d, p5/m, z17.d, z26.d
+    __ sve_fnmls(z22, __ D, p7, z12, z14);             //	fnmls	z22.d, p7/m, z12.d, z14.d
+    __ sve_mla(z27, __ H, p7, z2, z4);                 //	mla	z27.h, p7/m, z2.h, z4.h
+    __ sve_mls(z24, __ D, p1, z24, z4);                //	mls	z24.d, p1/m, z24.d, z4.d
+    __ sve_and(z30, z14, z22);                         //	and	z30.d, z14.d, z22.d
+    __ sve_eor(z28, z11, z22);                         //	eor	z28.d, z11.d, z22.d
+    __ sve_orr(z0, z12, z6);                           //	orr	z0.d, z12.d, z6.d
+    __ sve_bic(z27, z13, z17);                         //	bic	z27.d, z13.d, z17.d
 
 // SVEReductionOp
-    __ sve_andv(v21, __ S, p6, z5);                    //       andv s21, p6, z5.s
-    __ sve_orv(v21, __ S, p4, z22);                    //       orv s21, p4, z22.s
-    __ sve_eorv(v29, __ B, p5, z19);                   //       eorv b29, p5, z19.b
-    __ sve_smaxv(v4, __ B, p4, z23);                   //       smaxv b4, p4, z23.b
-    __ sve_sminv(v19, __ D, p1, z23);                  //       sminv d19, p1, z23.d
-    __ sve_fminv(v19, __ S, p0, z8);                   //       fminv s19, p0, z8.s
-    __ sve_fmaxv(v14, __ D, p6, z17);                  //       fmaxv d14, p6, z17.d
-    __ sve_fadda(v21, __ S, p1, z30);                  //       fadda s21, p1, s21, z30.s
-    __ sve_uaddv(v10, __ B, p5, z12);                  //       uaddv d10, p5, z12.b
+    __ sve_andv(v17, __ B, p3, z20);                   //	andv b17, p3, z20.b
+    __ sve_orv(v30, __ D, p2, z16);                    //	orv d30, p2, z16.d
+    __ sve_eorv(v9, __ B, p6, z17);                    //	eorv b9, p6, z17.b
+    __ sve_smaxv(v2, __ B, p7, z24);                   //	smaxv b2, p7, z24.b
+    __ sve_sminv(v6, __ S, p6, z19);                   //	sminv s6, p6, z19.s
+    __ sve_fminv(v9, __ S, p1, z23);                   //	fminv s9, p1, z23.s
+    __ sve_fmaxv(v24, __ S, p3, z19);                  //	fmaxv s24, p3, z19.s
+    __ sve_fadda(v17, __ D, p5, z4);                   //	fadda d17, p5, d17, z4.d
+    __ sve_uaddv(v8, __ D, p1, z17);                   //	uaddv d8, p1, z17.d
 
     __ bind(forth);
 
@@ -951,207 +952,207 @@
 
   static const unsigned int insns[] =
   {
-    0x8b0d82fa,     0xcb49970c,     0xab889dfc,     0xeb9ee787,
-    0x0b9b3ec9,     0x4b9179a3,     0x2b88474e,     0x6b8c56c0,
-    0x8a1a51e0,     0xaa11f4ba,     0xca0281b8,     0xea918c7c,
-    0x0a5d4a19,     0x2a4b262d,     0x4a513ca5,     0x6a9b6ae2,
-    0x8a70b79b,     0xaaba9728,     0xca6dfe3d,     0xea627f1c,
-    0x0aa70f53,     0x2aaa0f06,     0x4a6176a4,     0x6a604eb0,
-    0x1105ed91,     0x3100583e,     0x5101f8bd,     0x710f0306,
-    0x9101a1a0,     0xb10a5cc8,     0xd10810aa,     0xf10fd061,
-    0x120cb166,     0x321764bc,     0x52174681,     0x720c0227,
-    0x9241018e,     0xb25a2969,     0xd278b411,     0xf26aad01,
-    0x14000000,     0x17ffffd7,     0x140002fb,     0x94000000,
-    0x97ffffd4,     0x940002f8,     0x3400000a,     0x34fffa2a,
-    0x34005eaa,     0x35000008,     0x35fff9c8,     0x35005e48,
-    0xb400000b,     0xb4fff96b,     0xb4005deb,     0xb500001d,
-    0xb5fff91d,     0xb5005d9d,     0x10000013,     0x10fff8b3,
-    0x10005d33,     0x90000013,     0x36300016,     0x3637f836,
-    0x36305cb6,     0x3758000c,     0x375ff7cc,     0x37585c4c,
-    0x128313a0,     0x528a32c7,     0x7289173b,     0x92ab3acc,
-    0xd2a0bf94,     0xf2c285e8,     0x9358722f,     0x330e652f,
-    0x53067f3b,     0x93577c53,     0xb34a1aac,     0xd35a4016,
-    0x13946c63,     0x93c3dbc8,     0x54000000,     0x54fff5a0,
-    0x54005a20,     0x54000001,     0x54fff541,     0x540059c1,
-    0x54000002,     0x54fff4e2,     0x54005962,     0x54000002,
-    0x54fff482,     0x54005902,     0x54000003,     0x54fff423,
-    0x540058a3,     0x54000003,     0x54fff3c3,     0x54005843,
-    0x54000004,     0x54fff364,     0x540057e4,     0x54000005,
-    0x54fff305,     0x54005785,     0x54000006,     0x54fff2a6,
-    0x54005726,     0x54000007,     0x54fff247,     0x540056c7,
-    0x54000008,     0x54fff1e8,     0x54005668,     0x54000009,
-    0x54fff189,     0x54005609,     0x5400000a,     0x54fff12a,
-    0x540055aa,     0x5400000b,     0x54fff0cb,     0x5400554b,
-    0x5400000c,     0x54fff06c,     0x540054ec,     0x5400000d,
-    0x54fff00d,     0x5400548d,     0x5400000e,     0x54ffefae,
-    0x5400542e,     0x5400000f,     0x54ffef4f,     0x540053cf,
-    0xd40658e1,     0xd4014d22,     0xd4046543,     0xd4273f60,
-    0xd44cad80,     0xd503201f,     0xd69f03e0,     0xd6bf03e0,
-    0xd5033fdf,     0xd5033e9f,     0xd50332bf,     0xd61f0200,
-    0xd63f0280,     0xc80a7d1b,     0xc800fea1,     0xc85f7fb1,
-    0xc85fff9d,     0xc89ffee1,     0xc8dffe95,     0x88167e7b,
-    0x880bfcd0,     0x885f7c11,     0x885ffd44,     0x889ffed8,
-    0x88dffe6a,     0x48017fc5,     0x4808fe2c,     0x485f7dc9,
-    0x485ffc27,     0x489ffe05,     0x48dffd82,     0x080a7c6c,
-    0x081cff4e,     0x085f7d5e,     0x085ffeae,     0x089ffd2d,
-    0x08dfff76,     0xc87f4d7c,     0xc87fcc5e,     0xc8220417,
-    0xc82cb5f0,     0x887f55b1,     0x887ff90b,     0x88382c2d,
-    0x883aedb5,     0xf819928b,     0xb803e21c,     0x381f713b,
-    0x781ce322,     0xf850f044,     0xb85e129e,     0x385e92f1,
-    0x785ff35d,     0x39801921,     0x7881318b,     0x78dce02b,
-    0xb8829313,     0xfc45f318,     0xbc5d50af,     0xfc001375,
-    0xbc1951b7,     0xf8008c0a,     0xb801dc03,     0x38009dca,
-    0x781fdf3d,     0xf8570e0c,     0xb85faecc,     0x385f6d6d,
-    0x785ebea0,     0x38804cd7,     0x789cbce3,     0x78df9c9c,
-    0xb89eed18,     0xfc40cd6e,     0xbc5bdd93,     0xfc103c14,
-    0xbc040c08,     0xf81a2783,     0xb81ca4eb,     0x381e855b,
-    0x7801b4e6,     0xf853654d,     0xb85d74af,     0x384095a2,
-    0x785ec5bc,     0x389e15a9,     0x789dc703,     0x78c06474,
-    0xb89ff667,     0xfc57e51e,     0xbc4155f9,     0xfc05a6ee,
-    0xbc1df408,     0xf835da2a,     0xb836d9a4,     0x3833580d,
-    0x7826cb6c,     0xf8706900,     0xb87ae880,     0x3865db2e,
-    0x78714889,     0x38a7789b,     0x78beca2f,     0x78f6c810,
-    0xb8bef956,     0xfc6afabd,     0xbc734963,     0xfc3d5b8d,
-    0xbc25fbb7,     0xf9189d05,     0xb91ecb1d,     0x39187a33,
-    0x791f226d,     0xf95aa2f3,     0xb9587bb7,     0x395f7176,
-    0x795d9143,     0x399e7e08,     0x799a2697,     0x79df3422,
-    0xb99c2624,     0xfd5c2374,     0xbd5fa1d9,     0xfd1d595a,
-    0xbd1b1869,     0x5800441b,     0x1800000b,     0xf8945060,
-    0xd8000000,     0xf8ae6ba0,     0xf99a0080,     0x1a070035,
-    0x3a0700a8,     0x5a0e0367,     0x7a11009b,     0x9a000380,
-    0xba1e030c,     0xda0f0320,     0xfa030301,     0x0b340b11,
-    0x2b2a278d,     0xcb22aa0f,     0x6b2d29bd,     0x8b2cce8c,
-    0xab2b877e,     0xcb21c8ee,     0xeb3ba47d,     0x3a4d400e,
-    0x7a5132c6,     0xba5e622e,     0xfa53814c,     0x3a52d8c2,
-    0x7a4d8924,     0xba4b3aab,     0xfa4d7882,     0x1a96804c,
-    0x1a912618,     0x5a90b0e6,     0x5a96976b,     0x9a9db06a,
-    0x9a9b374c,     0xda95c14f,     0xda89c6fe,     0x5ac0015e,
-    0x5ac005fd,     0x5ac00bdd,     0x5ac012b9,     0x5ac01404,
-    0xdac002b1,     0xdac0061d,     0xdac00a95,     0xdac00e66,
-    0xdac0107e,     0xdac01675,     0x1ac00b0b,     0x1ace0f3b,
-    0x1ad121c3,     0x1ad825e7,     0x1ad92a3c,     0x1adc2f42,
-    0x9ada0b25,     0x9ad10e1b,     0x9acc22a6,     0x9acc2480,
-    0x9adc2a3b,     0x9ad12c5c,     0x9bce7dea,     0x9b597c6e,
-    0x1b0e166f,     0x1b1ae490,     0x9b023044,     0x9b089e3d,
-    0x9b391083,     0x9b24c73a,     0x9bb15f40,     0x9bbcc6af,
-    0x7ea3d55b,     0x1e3908e0,     0x1e2f18c9,     0x1e2a29fd,
-    0x1e273a22,     0x7ef7d56b,     0x1e770ba7,     0x1e6b1b6e,
-    0x1e78288b,     0x1e6e39ec,     0x1f1c3574,     0x1f17f98b,
-    0x1f2935da,     0x1f2574ea,     0x1f4b306f,     0x1f5ec7cf,
-    0x1f6f3e93,     0x1f6226a9,     0x1e2040fb,     0x1e20c3dd,
-    0x1e214031,     0x1e21c0c2,     0x1e22c06a,     0x1e604178,
-    0x1e60c027,     0x1e61400b,     0x1e61c223,     0x1e6240dc,
-    0x1e3800d6,     0x9e380360,     0x1e78005a,     0x9e7800e5,
-    0x1e22017c,     0x9e2201b9,     0x1e6202eb,     0x9e620113,
-    0x1e2602b1,     0x9e660299,     0x1e270233,     0x9e6703a2,
-    0x1e2822c0,     0x1e7322a0,     0x1e202288,     0x1e602168,
-    0x293c19f4,     0x2966387b,     0x69762970,     0xa9041dc7,
-    0xa9475c0c,     0x29b61ccd,     0x29ee3c5e,     0x69ee0764,
-    0xa9843977,     0xa9f46ebd,     0x28ba16b6,     0x28fc44db,
-    0x68f61430,     0xa8b352cd,     0xa8c56d5e,     0x28024565,
-    0x2874134e,     0xa8027597,     0xa87b1aa0,     0x0c40734f,
-    0x4cdfa177,     0x0cc76ee8,     0x4cdf2733,     0x0d40c23d,
-    0x4ddfcaf8,     0x0dd9ccaa,     0x4c408d51,     0x0cdf85ec,
-    0x4d60c239,     0x0dffcbc1,     0x4de9ce30,     0x4cc24999,
-    0x0c404a7a,     0x4d40e6af,     0x4ddfe9b9,     0x0dddef8e,
-    0x4cdf07b1,     0x0cc000fb,     0x0d60e238,     0x0dffe740,
-    0x0de2eb2c,     0x0e31baf6,     0x4e31bb9b,     0x0e71b8a4,
-    0x4e71b907,     0x4eb1b8e6,     0x0e30a841,     0x4e30ab7a,
-    0x0e70aa0f,     0x4e70a862,     0x4eb0a9cd,     0x6e30f9cd,
-    0x0e31ab38,     0x2e31ab17,     0x4e31a8a4,     0x6e31aa93,
-    0x0e71aa0f,     0x2e71a820,     0x4e71a8a4,     0x6e71aab4,
-    0x4eb1a98b,     0x6eb1abdd,     0x6eb0fa0f,     0x7e30fad5,
-    0x7e70f8a4,     0x7eb0f9ee,     0x7ef0faf6,     0x0e20bb59,
-    0x4e20b8e6,     0x0e60b9ac,     0x4e60b9ee,     0x0ea0b9cd,
-    0x4ea0b9ee,     0x4ee0b949,     0x0ea0fb59,     0x4ea0fbbc,
-    0x4ee0f96a,     0x2ea0fa93,     0x6ea0f98b,     0x6ee0fa51,
-    0x2ea1fad5,     0x6ea1fa0f,     0x6ee1fab4,     0x2e205b17,
-    0x6e205b7a,     0x0e271cc5,     0x4e281ce6,     0x0eb11e0f,
-    0x4eb11e0f,     0x2e3b1f59,     0x6e321e30,     0x0e3d879b,
-    0x4e3a8738,     0x0e71860f,     0x4e7b8759,     0x0eb085ee,
-    0x4eac856a,     0x4eef85cd,     0x0e30d5ee,     0x4e36d6b4,
-    0x4e63d441,     0x2e3886f6,     0x6e2087fe,     0x2e7085ee,
-    0x6e648462,     0x2ea884e6,     0x6ea58483,     0x6ee98507,
-    0x0ebad738,     0x4ea2d420,     0x4efdd79b,     0x0e3f9fdd,
-    0x4e279cc5,     0x0e679cc5,     0x4e7f9fdd,     0x0ead9d8b,
-    0x4ebb9f59,     0x2ea2d420,     0x6ea0d7fe,     0x6ee2d420,
-    0x2e33de51,     0x6e3edfbc,     0x6e7bdf59,     0x0e6b9549,
-    0x4e7b9759,     0x0eae95ac,     0x4eb1960f,     0x0e2dcd8b,
-    0x4e2ccd6a,     0x4e73ce51,     0x2e7a9738,     0x6e7796d5,
-    0x2eb99717,     0x6ea29420,     0x0eb2ce30,     0x4eaccd6a,
-    0x4ee8cce6,     0x2e3effbc,     0x6e28fce6,     0x6e67fcc5,
-    0x0e2764c5,     0x4e3666b4,     0x0e736651,     0x4e71660f,
-    0x0eb36651,     0x4ebf67dd,     0x0e3ca77a,     0x4e3ea7bc,
-    0x0e63a441,     0x4e7da79b,     0x0ea2a420,     0x4eb6a6b4,
-    0x0e3ef7bc,     0x4e31f60f,     0x4e6ef5ac,     0x0e2c6d6a,
-    0x4e3e6fbc,     0x0e7e6fbc,     0x4e756e93,     0x0eb86ef6,
-    0x4eac6d6a,     0x0e26aca4,     0x4e20affe,     0x0e76aeb4,
-    0x4e6aad28,     0x0ea0affe,     0x4eb3ae51,     0x0eacf56a,
-    0x4ebdf79b,     0x4ee4f462,     0x2e3a8f38,     0x6e268ca4,
-    0x2e658c83,     0x6e6a8d28,     0x2eb88ef6,     0x6eb38e51,
-    0x6eef8dcd,     0x0e26e4a4,     0x4e3ee7bc,     0x4e79e717,
-    0x0e3736d5,     0x4e3b3759,     0x0e7a3738,     0x4e653483,
-    0x0eb93717,     0x4ebc377a,     0x4ef93717,     0x2e3035ee,
-    0x6e3736d5,     0x2e653483,     0x6e793717,     0x2eaa3528,
-    0x6eba3738,     0x6ef53693,     0x2e313e0f,     0x6e323e30,
-    0x2e643c62,     0x6e633c41,     0x2ea23c20,     0x6eba3f38,
-    0x6ee63ca4,     0x2ea5e483,     0x6eade58b,     0x6ee0e7fe,
-    0x0e3d3f9b,     0x4e2b3d49,     0x0e7b3f59,     0x4e643c62,
-    0x0eae3dac,     0x4eb33e51,     0x4ee03ffe,     0x2e23e441,
-    0x6e2ee5ac,     0x6e7ee7bc,     0xba5fd3e3,     0x3a5f03e5,
-    0xfa411be4,     0x7a42cbe2,     0x93df03ff,     0xc820ffff,
-    0x8822fc7f,     0xc8247cbf,     0x88267fff,     0x4e010fe0,
-    0x4e081fe1,     0x4e0c1fe1,     0x4e0a1fe1,     0x4e071fe1,
-    0x4e042c20,     0x4e062c20,     0x4e052c20,     0x4e083c20,
-    0x0e0c3c20,     0x0e0a3c20,     0x0e073c20,     0x4cc0ac3f,
-    0x05a08020,     0x04b0e3e0,     0x0470e7e1,     0x042f9c20,
-    0x043f9c35,     0x047f9c20,     0x04ff9c20,     0x04299420,
-    0x04319160,     0x0461943e,     0x04a19020,     0x042053ff,
-    0x047f5401,     0x25208028,     0x2538cfe0,     0x2578d001,
-    0x25b8efe2,     0x25f8f007,     0xa400a3e0,     0xa4a8a7ea,
-    0xa547a814,     0xa4084ffe,     0xa55c53e0,     0xa5e1540b,
-    0xe400fbf6,     0xe408ffff,     0xe547e400,     0xe4014be0,
-    0xe4a84fe0,     0xe5f15000,     0x858043e0,     0x85a043ff,
-    0xe59f5d08,     0x1e601000,     0x1e603000,     0x1e621000,
-    0x1e623000,     0x1e641000,     0x1e643000,     0x1e661000,
-    0x1e663000,     0x1e681000,     0x1e683000,     0x1e6a1000,
-    0x1e6a3000,     0x1e6c1000,     0x1e6c3000,     0x1e6e1000,
-    0x1e6e3000,     0x1e701000,     0x1e703000,     0x1e721000,
-    0x1e723000,     0x1e741000,     0x1e743000,     0x1e761000,
-    0x1e763000,     0x1e781000,     0x1e783000,     0x1e7a1000,
-    0x1e7a3000,     0x1e7c1000,     0x1e7c3000,     0x1e7e1000,
-    0x1e7e3000,     0xf8208193,     0xf83101b6,     0xf83c13fe,
-    0xf821239a,     0xf824309e,     0xf826535e,     0xf8304109,
-    0xf82c7280,     0xf8216058,     0xf8a08309,     0xf8ba03d0,
-    0xf8a312ea,     0xf8aa21e4,     0xf8a2310b,     0xf8aa522f,
-    0xf8a2418a,     0xf8ac71af,     0xf8a26287,     0xf8fa8090,
-    0xf8e20184,     0xf8f01215,     0xf8f022ab,     0xf8f7334c,
-    0xf8f751dc,     0xf8eb4038,     0xf8ec715f,     0xf8f06047,
-    0xf863826d,     0xf8710070,     0xf86113cb,     0xf86521e8,
-    0xf87d301e,     0xf8745287,     0xf87742bc,     0xf87b70b9,
-    0xf8616217,     0xb83f8185,     0xb82901fc,     0xb83d13f6,
-    0xb83320bf,     0xb82e33f0,     0xb830529b,     0xb830416c,
-    0xb82973c6,     0xb831639b,     0xb8be8147,     0xb8b4008a,
-    0xb8b81231,     0xb8b623a3,     0xb8af3276,     0xb8b35056,
-    0xb8af4186,     0xb8b071ab,     0xb8b763c1,     0xb8f38225,
-    0xb8e202d0,     0xb8ed12aa,     0xb8fd219b,     0xb8fb3023,
-    0xb8ff5278,     0xb8f14389,     0xb8fb70ef,     0xb8f563f7,
-    0xb87983e2,     0xb87b0150,     0xb8771073,     0xb8702320,
-    0xb87a3057,     0xb870508c,     0xb87c43be,     0xb87070db,
-    0xb86961fd,     0xce273c87,     0xce080ac9,     0xce7e8e9b,
-    0xce808b45,     0xce79806e,     0xce758768,     0xcec0835a,
-    0xce608ad8,     0x043100c4,     0x046105e3,     0x65c900a6,
-    0x65d60a87,     0x65c80545,     0x0416a63e,     0x04001f8b,
-    0x0450979a,     0x04dabe0d,     0x045381a5,     0x04918b4f,
-    0x049006cb,     0x0497a264,     0x045eadd1,     0x04881062,
-    0x040a04d7,     0x04810f71,     0x04dca450,     0x65c084c3,
-    0x65cd8d93,     0x65c69a68,     0x65878ae0,     0x65c29db3,
-    0x049da0e6,     0x6582b911,     0x65c0b6d6,     0x65c1a1e2,
-    0x65cda494,     0x65c18107,     0x65af1493,     0x65e52b36,
-    0x65ab4ed0,     0x65f06a8d,     0x0451448f,     0x049c7c86,
-    0x0429335d,     0x04bc3162,     0x047a3027,     0x04e831d1,
-    0x049a38b5,     0x049832d5,     0x0419367d,     0x040832e4,
-    0x04ca26f3,     0x65872113,     0x65c63a2e,     0x659827d5,
-    0x0401358a,
+    0x8b58159b,     0xcb50cfc8,     0xab5af73d,     0xeb1c462b, 
+    0x0b184089,     0x4b96263d,     0x2b175469,     0x6b436e2f, 
+    0x8a14f66a,     0xaa501f6e,     0xca112fb9,     0xea8c0357, 
+    0x0a5a3df3,     0x2a163157,     0x4a07263d,     0x6a0e1639, 
+    0x8a70378a,     0xaaa93e29,     0xcaba6951,     0xeab3933e, 
+    0x0a73504e,     0x2a2930f1,     0x4aa140ba,     0x6aa2204f, 
+    0x11013c9c,     0x310c845a,     0x5108d2da,     0x71078b30, 
+    0x910d68db,     0xb10e6911,     0xd10b6eaf,     0xf103b142, 
+    0x12133a2f,     0x320d0c07,     0x520a10f6,     0x721b3daa, 
+    0x926e2899,     0xb27e4e3a,     0xd2520683,     0xf26d684c, 
+    0x14000000,     0x17ffffd7,     0x140002fc,     0x94000000, 
+    0x97ffffd4,     0x940002f9,     0x34000001,     0x34fffa21, 
+    0x34005ec1,     0x35000013,     0x35fff9d3,     0x35005e73, 
+    0xb4000000,     0xb4fff960,     0xb4005e00,     0xb5000006, 
+    0xb5fff906,     0xb5005da6,     0x1000001e,     0x10fff8be, 
+    0x10005d5e,     0x90000005,     0x36180016,     0x361ff836, 
+    0x36185cd6,     0x3730000f,     0x3737f7cf,     0x37305c6f, 
+    0x1281f477,     0x528d9eb1,     0x7288515a,     0x92c24d87, 
+    0xd2adf44b,     0xf28ef2a1,     0x93593073,     0x331e2968, 
+    0x530d0eb6,     0x934a2ab9,     0xb3501e0a,     0xd35c2fb3, 
+    0x139569e0,     0x93db9e3c,     0x54000000,     0x54fff5a0, 
+    0x54005a40,     0x54000001,     0x54fff541,     0x540059e1, 
+    0x54000002,     0x54fff4e2,     0x54005982,     0x54000002, 
+    0x54fff482,     0x54005922,     0x54000003,     0x54fff423, 
+    0x540058c3,     0x54000003,     0x54fff3c3,     0x54005863, 
+    0x54000004,     0x54fff364,     0x54005804,     0x54000005, 
+    0x54fff305,     0x540057a5,     0x54000006,     0x54fff2a6, 
+    0x54005746,     0x54000007,     0x54fff247,     0x540056e7, 
+    0x54000008,     0x54fff1e8,     0x54005688,     0x54000009, 
+    0x54fff189,     0x54005629,     0x5400000a,     0x54fff12a, 
+    0x540055ca,     0x5400000b,     0x54fff0cb,     0x5400556b, 
+    0x5400000c,     0x54fff06c,     0x5400550c,     0x5400000d, 
+    0x54fff00d,     0x540054ad,     0x5400000e,     0x54ffefae, 
+    0x5400544e,     0x5400000f,     0x54ffef4f,     0x540053ef, 
+    0xd40b6dc1,     0xd40c6fc2,     0xd40807a3,     0xd424e8c0, 
+    0xd44065e0,     0xd503201f,     0xd69f03e0,     0xd6bf03e0, 
+    0xd5033fdf,     0xd50330ff,     0xd5033a9f,     0xd5033fbf, 
+    0xd61f0040,     0xd63f0140,     0xc8177e21,     0xc808fce4, 
+    0xc85f7fd8,     0xc85ffd6f,     0xc89ffd33,     0xc8dffd75, 
+    0x88117f9e,     0x8814fe7b,     0x885f7ec4,     0x885ffd89, 
+    0x889ffdb7,     0x88dffe9a,     0x48027e60,     0x4806fd56, 
+    0x485f7ce5,     0x485ffe87,     0x489ffd8e,     0x48dfff96, 
+    0x08157f71,     0x080dfd81,     0x085f7edb,     0x085ffdb1, 
+    0x089ffeb8,     0x08dffc36,     0xc87f3845,     0xc87fd8a8, 
+    0xc82e71f0,     0xc83dcf11,     0x887f7020,     0x887fa92f, 
+    0x883a072e,     0x883ae5bc,     0xf80450ca,     0xb8183013, 
+    0x381f3294,     0x781e305b,     0xf850909e,     0xb858a22b, 
+    0x385eb364,     0x785eb108,     0x398014af,     0x789c62fa, 
+    0x78df515a,     0xb89d7329,     0xfc45f159,     0xbc43f051, 
+    0xfc1e520b,     0xbc0150fa,     0xf810ecc8,     0xb801ff71, 
+    0x381fffbe,     0x781fff17,     0xf8512ee9,     0xb8590d21, 
+    0x385f5c30,     0x78402e9d,     0x389f8d25,     0x789ead9a, 
+    0x78dd0c8d,     0xb8837dd4,     0xfc533d94,     0xbc40cd43, 
+    0xfc066f99,     0xbc1cbf79,     0xf81e97a8,     0xb80117bb, 
+    0x3800167d,     0x781f5740,     0xf850f462,     0xb85d97b4, 
+    0x3840a417,     0x785d7488,     0x389f5453,     0x789d44f0, 
+    0x78def6e2,     0xb880c44b,     0xfc4464e0,     0xbc5f05a2, 
+    0xfc1397c5,     0xbc1bf70e,     0xf834fa80,     0xb829f8c2, 
+    0x382f5abc,     0x7821eab7,     0xf86b4919,     0xb869690d, 
+    0x38695b7e,     0x7871ca85,     0x38b6786b,     0x78afda94, 
+    0x78e14bc0,     0xb8afe96b,     0xfc636838,     0xbc69ea2a, 
+    0xfc34c9a6,     0xbc25ebb9,     0xf91c6cd4,     0xb91d8c53, 
+    0x391d2854,     0x791dc6c8,     0xf95966cb,     0xb95db011, 
+    0x395b47aa,     0x79596a22,     0x399808d0,     0x799faf7d, 
+    0x79de062f,     0xb99b29dc,     0xfd5c9fa7,     0xbd5de9f3, 
+    0xfd1eca27,     0xbd1d4409,     0x5800440c,     0x18000017, 
+    0xf897b340,     0xd8000000,     0xf8bc6880,     0xf99f87a0, 
+    0x1a13016c,     0x3a140091,     0x5a1d038f,     0x7a1a0263, 
+    0x9a130200,     0xba0e01eb,     0xda1e0009,     0xfa140227, 
+    0x0b3cf2a5,     0x2b368551,     0xcb2caa64,     0x6b2c6539, 
+    0x8b37a941,     0xab3589db,     0xcb250eab,     0xeb31462b, 
+    0x3a401160,     0x7a4150ea,     0xba5a904d,     0xfa5cc08d, 
+    0x3a4b9889,     0x7a588a8d,     0xba5db808,     0xfa5a1b03, 
+    0x1a85019e,     0x1a933490,     0x5a873142,     0x5a8037c7, 
+    0x9a9a3337,     0x9a8d2456,     0xda8e3293,     0xda816673, 
+    0x5ac0032a,     0x5ac006f7,     0x5ac0080c,     0x5ac013b4, 
+    0x5ac0143c,     0xdac0004f,     0xdac0052b,     0xdac00895, 
+    0xdac00cee,     0xdac01170,     0xdac016e5,     0x1aca0998, 
+    0x1acf0f28,     0x1ac0219e,     0x1adc2609,     0x1acf2a29, 
+    0x1ad12f01,     0x9ac80a31,     0x9ac10ebd,     0x9ad7218e, 
+    0x9acb2583,     0x9ac0282f,     0x9ac12ee8,     0x9bd57ea8, 
+    0x9b587ed1,     0x1b15613d,     0x1b10c306,     0x9b1a218a, 
+    0x9b11a866,     0x9b3e77d9,     0x9b35de27,     0x9bbc2eb1, 
+    0x9bbbf3a5,     0x7ebbd544,     0x1e200b57,     0x1e211b51, 
+    0x1e3e2891,     0x1e29396b,     0x7eead534,     0x1e6c0b2f, 
+    0x1e6519b3,     0x1e642b20,     0x1e6e3831,     0x1f1d0144, 
+    0x1f0ff6fe,     0x1f3a56be,     0x1f374d18,     0x1f517446, 
+    0x1f5ee90d,     0x1f650a05,     0x1f654695,     0x1e2043c3, 
+    0x1e20c290,     0x1e214239,     0x1e21c193,     0x1e22c1b8, 
+    0x1e604128,     0x1e60c009,     0x1e61430d,     0x1e61c2da, 
+    0x1e6243c8,     0x1e380228,     0x9e380230,     0x1e78014a, 
+    0x9e7802c6,     0x1e2201b9,     0x9e220099,     0x1e62001b, 
+    0x9e620218,     0x1e260324,     0x9e6602d5,     0x1e27033d, 
+    0x9e670191,     0x1e2e2160,     0x1e6123c0,     0x1e202228, 
+    0x1e6023a8,     0x293a4f34,     0x2950400b,     0x696a568b, 
+    0xa90602ef,     0xa9472387,     0x29aa61be,     0x29e45dd8, 
+    0x69c00cd7,     0xa9b575ae,     0xa9c437a8,     0x28902d58, 
+    0x28e46500,     0x68ec66ad,     0xa88433b5,     0xa8f14c9b, 
+    0x28042156,     0x286013b0,     0xa8314762,     0xa87b5c46, 
+    0x0c40707c,     0x4cdfa09b,     0x0cd06d3a,     0x4cdf2622, 
+    0x0d40c23d,     0x4ddfc89a,     0x0dc2cfd6,     0x4c408d40, 
+    0x0cdf875a,     0x4d60c197,     0x0dffc899,     0x4dfdcd81, 
+    0x4ccb49c5,     0x0c404800,     0x4d40e579,     0x4ddfea20, 
+    0x0dd0ee84,     0x4cdf07be,     0x0cd6022f,     0x0d60e3ca, 
+    0x0dffe4bc,     0x0de4ea24,     0x0e31b820,     0x4e31b820, 
+    0x0e71bb7a,     0x4e71b96a,     0x4eb1ba30,     0x0e30a820, 
+    0x4e30a841,     0x0e70a841,     0x4e70ab38,     0x4eb0abdd, 
+    0x6e30f883,     0x0e31aa51,     0x2e31aa93,     0x4e31a8a4, 
+    0x6e31ab38,     0x0e71a8a4,     0x2e71aad5,     0x4e71ab59, 
+    0x6e71a9ac,     0x4eb1ab59,     0x6eb1a820,     0x6eb0f9cd, 
+    0x7e30f9cd,     0x7e70fa51,     0x7eb0fbdd,     0x7ef0fad5, 
+    0x0e20b96a,     0x4e20baf6,     0x0e60b907,     0x4e60bbdd, 
+    0x0ea0b8a4,     0x4ea0b98b,     0x4ee0ba30,     0x0ea0f8e6, 
+    0x4ea0fa51,     0x4ee0f9ac,     0x2ea0f862,     0x6ea0f8a4, 
+    0x6ee0f9cd,     0x2ea1fa51,     0x6ea1fad5,     0x6ee1f98b, 
+    0x2e205bfe,     0x6e205883,     0x0e2f1dcd,     0x4e3e1fbc, 
+    0x0eaf1dcd,     0x4ea91d07,     0x2e311e0f,     0x6e2e1dac, 
+    0x0e298507,     0x4e3f87dd,     0x0e6e85ac,     0x4e698507, 
+    0x0eb686b4,     0x4eb1860f,     0x4eee85ac,     0x0e3fd7dd, 
+    0x4e33d651,     0x4e64d462,     0x2e3c877a,     0x6e2a8528, 
+    0x2e6a8528,     0x6e7e87bc,     0x2eb28630,     0x6ead858b, 
+    0x6ef38651,     0x0ea2d420,     0x4eb5d693,     0x4ef5d693, 
+    0x0e3a9f38,     0x4e319e0f,     0x0e7e9fbc,     0x4e699d07, 
+    0x0eaa9d28,     0x4ea39c41,     0x2eb5d693,     0x6eacd56a, 
+    0x6efdd79b,     0x2e3bdf59,     0x6e2eddac,     0x6e60dffe, 
+    0x0e7696b4,     0x4e659483,     0x0eb39651,     0x4ebe97bc, 
+    0x0e3dcf9b,     0x4e23cc41,     0x4e66cca4,     0x2e7896f6, 
+    0x6e6e95ac,     0x2ea29420,     0x6eba9738,     0x0eafcdcd, 
+    0x4eb9cf17,     0x4efdcf9b,     0x2e2efdac,     0x6e2ffdcd, 
+    0x6e7fffdd,     0x0e256483,     0x4e3866f6,     0x0e7065ee, 
+    0x4e756693,     0x0eb065ee,     0x4ea764c5,     0x0e27a4c5, 
+    0x4e2ca56a,     0x0e71a60f,     0x4e6fa5cd,     0x0ea7a4c5, 
+    0x4eb3a651,     0x0e3ff7dd,     0x4e3df79b,     0x4e6bf549, 
+    0x0e3a6f38,     0x4e326e30,     0x0e656c83,     0x4e7f6fdd, 
+    0x0ead6d8b,     0x4ead6d8b,     0x0e26aca4,     0x4e36aeb4, 
+    0x0e6dad8b,     0x4e7aaf38,     0x0eb1ae0f,     0x4eb6aeb4, 
+    0x0eb2f630,     0x4ebaf738,     0x4ee3f441,     0x2e288ce6, 
+    0x6e3e8fbc,     0x2e608ffe,     0x6e6a8d28,     0x2ea78cc5, 
+    0x6eb98f17,     0x6ef38e51,     0x0e2ce56a,     0x4e2be549, 
+    0x4e6ee5ac,     0x0e3636b4,     0x4e233441,     0x0e6b3549, 
+    0x4e733651,     0x0eaf35cd,     0x4ea33441,     0x4ef736d5, 
+    0x2e2f35cd,     0x6e2a3528,     0x2e6e35ac,     0x6e793717, 
+    0x2ea834e6,     0x6ead358b,     0x6ee634a4,     0x2e263ca4, 
+    0x6e253c83,     0x2e753e93,     0x6e6d3d8b,     0x2ea73cc5, 
+    0x6ea23c20,     0x6eef3dcd,     0x2eb3e651,     0x6eaee5ac, 
+    0x6ef0e5ee,     0x0e243c62,     0x4e363eb4,     0x0e783ef6, 
+    0x4e783ef6,     0x0eb73ed5,     0x4ea43c62,     0x4efa3f38, 
+    0x2e2fe5cd,     0x6e33e651,     0x6e79e717,     0xba5fd3e3, 
+    0x3a5f03e5,     0xfa411be4,     0x7a42cbe2,     0x93df03ff, 
+    0xc820ffff,     0x8822fc7f,     0xc8247cbf,     0x88267fff, 
+    0x4e010fe0,     0x4e081fe1,     0x4e0c1fe1,     0x4e0a1fe1, 
+    0x4e071fe1,     0x4e042c20,     0x4e062c20,     0x4e052c20, 
+    0x4e083c20,     0x0e0c3c20,     0x0e0a3c20,     0x0e073c20, 
+    0x4cc0ac3f,     0x05a08020,     0x04b0e3e0,     0x0470e7e1, 
+    0x042f9c20,     0x043f9c35,     0x047f9c20,     0x04ff9c20, 
+    0x04299420,     0x04319160,     0x0461943e,     0x04a19020, 
+    0x042053ff,     0x047f5401,     0x25208028,     0x2538cfe0, 
+    0x2578d001,     0x25b8efe2,     0x25f8f007,     0xa400a3e0, 
+    0xa4a8a7ea,     0xa547a814,     0xa4084ffe,     0xa55c53e0, 
+    0xa5e1540b,     0xe400fbf6,     0xe408ffff,     0xe547e400, 
+    0xe4014be0,     0xe4a84fe0,     0xe5f15000,     0x858043e0, 
+    0x85a043ff,     0xe59f5d08,     0x1e601000,     0x1e603000, 
+    0x1e621000,     0x1e623000,     0x1e641000,     0x1e643000, 
+    0x1e661000,     0x1e663000,     0x1e681000,     0x1e683000, 
+    0x1e6a1000,     0x1e6a3000,     0x1e6c1000,     0x1e6c3000, 
+    0x1e6e1000,     0x1e6e3000,     0x1e701000,     0x1e703000, 
+    0x1e721000,     0x1e723000,     0x1e741000,     0x1e743000, 
+    0x1e761000,     0x1e763000,     0x1e781000,     0x1e783000, 
+    0x1e7a1000,     0x1e7a3000,     0x1e7c1000,     0x1e7c3000, 
+    0x1e7e1000,     0x1e7e3000,     0xf828812a,     0xf82d01ca, 
+    0xf82113e8,     0xf83622b0,     0xf827321a,     0xf82a52b5, 
+    0xf8294278,     0xf82f72d8,     0xf838627e,     0xf8ba80da, 
+    0xf8a90009,     0xf8a610ed,     0xf8b1230a,     0xf8a53002, 
+    0xf8a753d7,     0xf8b44386,     0xf8b773f0,     0xf8ae608a, 
+    0xf8ea8141,     0xf8fa038d,     0xf8f91030,     0xf8e82158, 
+    0xf8fc3303,     0xf8e552b9,     0xf8ee405d,     0xf8fe7226, 
+    0xf8ff63d9,     0xf87081cb,     0xf877026a,     0xf869109d, 
+    0xf864233e,     0xf87a3205,     0xf87e50ee,     0xf87042e9, 
+    0xf8667068,     0xf868600c,     0xb82283f9,     0xb82602de, 
+    0xb8351006,     0xb82f23ee,     0xb83331d1,     0xb82052df, 
+    0xb8354085,     0xb83371db,     0xb8376138,     0xb8ae8190, 
+    0xb8be01f6,     0xb8b810e8,     0xb8b923d6,     0xb8ae32d7, 
+    0xb8bb52d1,     0xb8b940d0,     0xb8be70f0,     0xb8bc62c9, 
+    0xb8ef82ab,     0xb8ff00ee,     0xb8f813b8,     0xb8fd232e, 
+    0xb8f331df,     0xb8f450a0,     0xb8fe4334,     0xb8ee707b, 
+    0xb8e260ba,     0xb870828c,     0xb86b0167,     0xb87711c1, 
+    0xb8622300,     0xb86030e8,     0xb86c53a5,     0xb86c4340, 
+    0xb86471cb,     0xb86e631a,     0xce20372f,     0xce180586, 
+    0xce688fd3,     0xce8bbe20,     0xce75815a,     0xce64868e, 
+    0xcec08213,     0xce7e8902,     0x04a302c3,     0x046406c0, 
+    0x65d100cc,     0x659009a6,     0x65d60471,     0x0456bde3, 
+    0x04c0148e,     0x04909848,     0x045aadda,     0x04d39f0b, 
+    0x04119ee0,     0x04d01bd1,     0x0497b8e7,     0x045ebc8f, 
+    0x04c8116e,     0x040a0b53,     0x040113a6,     0x04dca09e, 
+    0x65809761,     0x658d9d98,     0x65869ccd,     0x65c7832c, 
+    0x65c28efc,     0x04ddb885,     0x65c2ae7c,     0x65c0ade1, 
+    0x6581ac11,     0x65cda8e1,     0x65818ebb,     0x65f41bbb, 
+    0x65b535fc,     0x65fa5625,     0x65ee7d96,     0x04445c5b, 
+    0x04c46718,     0x043631de,     0x04b6317c,     0x04663180, 
+    0x04f131bb,     0x041a2e91,     0x04d82a1e,     0x04193a29, 
+    0x04083f02,     0x048a3a66,     0x658726e9,     0x65862e78, 
+    0x65d83491,     0x04c12628, 
   };
 // END  Generated code -- do not edit

--- a/test/hotspot/jtreg/compiler/onSpinWait/TestOnSpinWaitAArch64.java
+++ b/test/hotspot/jtreg/compiler/onSpinWait/TestOnSpinWaitAArch64.java
@@ -33,9 +33,11 @@
  * @run driver compiler.onSpinWait.TestOnSpinWaitAArch64 c2 nop 7
  * @run driver compiler.onSpinWait.TestOnSpinWaitAArch64 c2 isb 3
  * @run driver compiler.onSpinWait.TestOnSpinWaitAArch64 c2 yield 1
+ * @run driver compiler.onSpinWait.TestOnSpinWaitAArch64 c2 sb 1
  * @run driver compiler.onSpinWait.TestOnSpinWaitAArch64 c1 nop 7
  * @run driver compiler.onSpinWait.TestOnSpinWaitAArch64 c1 isb 3
- * @run driver compiler.onSpinWait.TestOnSpinWaitAArch64 c1 yield
+ * @run driver compiler.onSpinWait.TestOnSpinWaitAArch64 c1 yield 1
+ * @run driver compiler.onSpinWait.TestOnSpinWaitAArch64 c1 sb 1
  */
 
 package compiler.onSpinWait;
@@ -50,13 +52,12 @@ public class TestOnSpinWaitAArch64 {
     public static void main(String[] args) throws Exception {
         String compiler = args[0];
         String spinWaitInst = args[1];
-        String spinWaitInstCount = (args.length == 3) ? args[2] : "1";
+        String spinWaitInstCount = args[2];
         ArrayList<String> command = new ArrayList<String>();
         command.add("-XX:+IgnoreUnrecognizedVMOptions");
         command.add("-showversion");
         command.add("-XX:-BackgroundCompilation");
         command.add("-XX:+UnlockDiagnosticVMOptions");
-        command.add("-XX:+PrintAssembly");
         if (compiler.equals("c2")) {
             command.add("-XX:-TieredCompilation");
         } else if (compiler.equals("c1")) {
@@ -69,17 +70,27 @@ public class TestOnSpinWaitAArch64 {
         command.add("-XX:OnSpinWaitInst=" + spinWaitInst);
         command.add("-XX:OnSpinWaitInstCount=" + spinWaitInstCount);
         command.add("-XX:CompileCommand=compileonly," + Launcher.class.getName() + "::" + "test");
+        command.add("-XX:CompileCommand=print," + Launcher.class.getName() + "::" + "test");
         command.add(Launcher.class.getName());
 
         ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder(command);
 
         OutputAnalyzer analyzer = new OutputAnalyzer(pb.start());
 
+        if ("sb".equals(spinWaitInst) && analyzerContains(analyzer, "CPU does not support SB")) {
+            System.out.println("Skipping the test. The current CPU does not support SB instruction.");
+            return;
+        }
+
         analyzer.shouldHaveExitValue(0);
 
         System.out.println(analyzer.getOutput());
 
         checkOutput(analyzer, spinWaitInst, Integer.parseInt(spinWaitInstCount));
+    }
+
+    private static boolean analyzerContains(OutputAnalyzer analyzer, String s) {
+        return analyzer.getStdout().contains(s) || analyzer.getStderr().contains(s);
     }
 
     private static String getSpinWaitInstHex(String spinWaitInst) {
@@ -89,6 +100,8 @@ public class TestOnSpinWaitAArch64 {
           return "df3f 03d5";
       } else if ("yield".equals(spinWaitInst)) {
           return "3f20 03d5";
+      } else if ("sb".equals(spinWaitInst)) {
+          return "ff30 03d5";
       } else {
           throw new RuntimeException("Unknown spin wait instruction: " + spinWaitInst);
       }


### PR DESCRIPTION
This pull request is a backport of https://bugs.openjdk.org/browse/JDK-8359435.
It adds support for the AArch64 SB (Speculation Barrier) instruction as an option for spin-wait operations in the JVM.

Differences between 17 and 26 required the following changes:
- Regenerate `test/hotspot/gtest/aarch64/asmtest.out.h`.
- Add a missing implementation of `analyzer.contains()` to `test/hotspot/jtreg/compiler/onSpinWait/TestOnSpinWaitAArch64.java`.

Tested on Graviton 4.