### PR TITLE
8360936: Test compiler/onSpinWait/TestOnSpinWaitAArch64.java fails after JDK-8359435

### DIFF
--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -5713,6 +5713,7 @@ void MacroAssembler::verify_cross_modify_fence_not_required() {
 #endif
 
 void MacroAssembler::spin_wait() {
+  block_comment("spin_wait {");
   for (int i = 0; i < VM_Version::spin_wait_desc().inst_count(); ++i) {
     switch (VM_Version::spin_wait_desc().inst()) {
       case SpinWait::NOP:
@@ -5731,4 +5732,5 @@ void MacroAssembler::spin_wait() {
         ShouldNotReachHere();
     }
   }
+  block_comment("}");
 }

--- a/test/hotspot/jtreg/compiler/onSpinWait/TestOnSpinWaitAArch64.java
+++ b/test/hotspot/jtreg/compiler/onSpinWait/TestOnSpinWaitAArch64.java
@@ -29,6 +29,7 @@
  *
  * @requires vm.flagless
  * @requires os.arch=="aarch64"
+ * @requires vm.debug
  *
  * @run driver compiler.onSpinWait.TestOnSpinWaitAArch64 c2 nop 7
  * @run driver compiler.onSpinWait.TestOnSpinWaitAArch64 c2 isb 3
@@ -42,6 +43,7 @@
 
 package compiler.onSpinWait;
 
+import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.ListIterator;
@@ -49,6 +51,7 @@ import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.ProcessTools;
 
 public class TestOnSpinWaitAArch64 {
+
     public static void main(String[] args) throws Exception {
         String compiler = args[0];
         String spinWaitInst = args[1];
@@ -95,125 +98,85 @@ public class TestOnSpinWaitAArch64 {
 
     private static String getSpinWaitInstHex(String spinWaitInst) {
       if ("nop".equals(spinWaitInst)) {
-          return "1f20 03d5";
+          return "1f2003d5";
       } else if ("isb".equals(spinWaitInst)) {
-          return "df3f 03d5";
+          return "df3f03d5";
       } else if ("yield".equals(spinWaitInst)) {
-          return "3f20 03d5";
+          return "3f2003d5";
       } else if ("sb".equals(spinWaitInst)) {
-          return "ff30 03d5";
+          return "ff3003d5";
       } else {
           throw new RuntimeException("Unknown spin wait instruction: " + spinWaitInst);
       }
     }
 
-    private static void addInstrs(String line, ArrayList<String> instrs) {
-        for (String instr : line.split("\\|")) {
-            instrs.add(instr.trim());
-        }
-    }
-
-    // The expected output of PrintAssembly for example for a spin wait with three NOPs:
+    // The expected output for a spin wait with three NOPs
+    // if the hsdis library is available:
     //
-    // # {method} {0x0000ffff6ac00370} 'test' '()V' in 'compiler/onSpinWait/TestOnSpinWaitAArch64$Launcher'
-    // #           [sp+0x40]  (sp of caller)
-    // 0x0000ffff9d557680: 1f20 03d5 | e953 40d1 | 3f01 00f9 | ff03 01d1 | fd7b 03a9 | 1f20 03d5 | 1f20 03d5
+    // ;; spin_wait {
+    // 0x0000000111dfa58c:   nop
+    // 0x0000000111dfa590:   nop
+    // 0x0000000111dfa594:   nop
+    // ;; }
     //
-    // 0x0000ffff9d5576ac: ;*invokestatic onSpinWait {reexecute=0 rethrow=0 return_oop=0}
-    //                     ; - compiler.onSpinWait.TestOnSpinWaitAArch64$Launcher::test@0 (line 161)
-    // 0x0000ffff9d5576ac: 1f20 03d5 | fd7b 43a9 | ff03 0191
-    //
-    // The checkOutput method adds hex instructions before 'invokestatic onSpinWait' and from the line after
-    // it to a list. The list is traversed from the end to count spin wait instructions.
-    //
-    // If JVM finds the hsdis library the output is like:
-    //
-    // # {method} {0x0000ffff63000370} 'test' '()V' in 'compiler/onSpinWait/TestOnSpinWaitAArch64$Launcher'
-    // #           [sp+0x20]  (sp of caller)
-    // 0x0000ffffa409da80:   nop
-    // 0x0000ffffa409da84:   sub sp, sp, #0x20
-    // 0x0000ffffa409da88:   stp x29, x30, [sp, #16]         ;*synchronization entry
-    //                                                       ; - compiler.onSpinWait.TestOnSpinWaitAArch64$Launcher::test@-1 (line 187)
-    // 0x0000ffffa409da8c:   nop
-    // 0x0000ffffa409da90:   nop
-    // 0x0000ffffa409da94:   nop
-    // 0x0000ffffa409da98:   nop
-    // 0x0000ffffa409da9c:   nop
-    // 0x0000ffffa409daa0:   nop
-    // 0x0000ffffa409daa4:   nop                                 ;*invokestatic onSpinWait {reexecute=0 rethrow=0 return_oop=0}
-    //                                                           ; - compiler.onSpinWait.TestOnSpinWaitAArch64$Launcher::test@0 (line 187)
-    private static void checkOutput(OutputAnalyzer output, String spinWaitInst, int spinWaitInstCount) {
+    private static void checkOutput(OutputAnalyzer output, final String spinWaitInst, final int expectedCount) {
         Iterator<String> iter = output.asLines().listIterator();
 
-        String match = skipTo(iter, "'test' '()V' in 'compiler/onSpinWait/TestOnSpinWaitAArch64$Launcher'");
-        if (match == null) {
-            throw new RuntimeException("Missing compiler output for the method compiler.onSpinWait.TestOnSpinWaitAArch64$Launcher::test");
-        }
-
-        ArrayList<String> instrs = new ArrayList<String>();
-        String line = null;
-        boolean hasHexInstInOutput = false;
+        // 1. Check whether printed instructions are disassembled
+        boolean isDisassembled = false;
         while (iter.hasNext()) {
-            line = iter.next();
-            if (line.contains("*invokestatic onSpinWait")) {
+            String line = iter.next();
+            if (line.contains("[Disassembly]")) {
+                isDisassembled = true;
                 break;
             }
-            if (!hasHexInstInOutput) {
-                hasHexInstInOutput = line.contains("|");
-            }
-            if (line.contains("0x") && !line.contains(";")) {
-                addInstrs(line, instrs);
-            }
-        }
-
-        if (!iter.hasNext() || !iter.next().contains("- compiler.onSpinWait.TestOnSpinWaitAArch64$Launcher::test@0") || !iter.hasNext()) {
-            throw new RuntimeException("Missing compiler output for Thread.onSpinWait intrinsic");
-        }
-
-        String strToSearch = null;
-        if (!hasHexInstInOutput) {
-            instrs.add(line.split(";")[0].trim());
-            strToSearch = spinWaitInst;
-        } else {
-            line = iter.next();
-            if (!line.contains("0x") || line.contains(";")) {
-                throw new RuntimeException("Expected hex instructions");
-            }
-
-            addInstrs(line, instrs);
-            strToSearch = getSpinWaitInstHex(spinWaitInst);
-        }
-
-        int foundInstCount = 0;
-
-        ListIterator<String> instrReverseIter = instrs.listIterator(instrs.size());
-        while (instrReverseIter.hasPrevious()) {
-            if (instrReverseIter.previous().endsWith(strToSearch)) {
-                foundInstCount = 1;
+            if (line.contains("[MachCode]")) {
                 break;
             }
         }
 
-        while (instrReverseIter.hasPrevious()) {
-            if (!instrReverseIter.previous().endsWith(strToSearch)) {
-                break;
-            }
-            ++foundInstCount;
-        }
-
-        if (foundInstCount != spinWaitInstCount) {
-            throw new RuntimeException("Wrong instruction " + strToSearch + " count " + foundInstCount + "!\n  -- expecting " + spinWaitInstCount);
-        }
-    }
-
-    private static String skipTo(Iterator<String> iter, String substring) {
+        // 2. Look for the block comment
+        boolean foundHead = false;
         while (iter.hasNext()) {
-            String nextLine = iter.next();
-            if (nextLine.contains(substring)) {
-                return nextLine;
+            String line = iter.next().trim();
+            if (line.contains(";; spin_wait {")) {
+                foundHead = true;
+                break;
             }
         }
-        return null;
+        if (!foundHead) {
+            throw new RuntimeException("Block comment not found");
+        }
+
+        // 3. Count spin wait instructions
+        final String expectedInst = isDisassembled ? spinWaitInst : getSpinWaitInstHex(spinWaitInst);
+        int foundCount = 0;
+        while (iter.hasNext()) {
+            String line = iter.next().trim();
+            if (line.startsWith(";; }")) {
+                break;
+            }
+            if (!line.startsWith("0x")) {
+                continue;
+            }
+            int pos = line.indexOf(':');
+            if (pos == -1 || pos == line.length() - 1) {
+                continue;
+            }
+            line = line.substring(pos + 1).replaceAll("\\s", "");
+            if (line.startsWith(";")) {
+                continue;
+            }
+            // When code is disassembled, we have one instruction per line.
+            // Otherwise, there can be multiple hex instructions separated by '|'.
+            foundCount += (int)Arrays.stream(line.split("\\|"))
+                                     .takeWhile(i -> i.startsWith(expectedInst))
+                                     .count();
+        }
+
+        if (foundCount != expectedCount) {
+            throw new RuntimeException("Expected " + expectedCount + " " + spinWaitInst + " instructions. Found: " + foundCount);
+        }
     }
 
     static class Launcher {


### PR DESCRIPTION
This pull request is a clean backport of https://bugs.openjdk.org/browse/JDK-8360936.

**Changes:**

* The test `TestOnSpinWaitAArch64.java` now requires the JVM to run in debug mode.
* The logic for verifying spin wait instruction output in `TestOnSpinWaitAArch64.java` has been refactored. The new approach checks for block comments delimiting the spin wait code and accurately counts the expected instructions, making the test more robust.
* The `spin_wait` method in `macroAssembler_aarch64.cpp` now emits block comments (`spin_wait {` and `}`) around the generated instructions, making it easier to identify spin wait code in assembly output.