### PR TITLE
Set OnSpinWaitInst to SB for Graviton 4

### DIFF
--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
@@ -229,7 +229,11 @@ void VM_Version::initialize() {
     }
 
     if (FLAG_IS_DEFAULT(OnSpinWaitInst)) {
-      FLAG_SET_DEFAULT(OnSpinWaitInst, "isb");
+      if (model_is(0xd4f)) {
+        FLAG_SET_DEFAULT(OnSpinWaitInst, "sb");
+      } else {
+        FLAG_SET_DEFAULT(OnSpinWaitInst, "isb");
+      }
     }
 
     if (FLAG_IS_DEFAULT(OnSpinWaitInstCount)) {


### PR DESCRIPTION
A clean backport of https://github.com/corretto/corretto-21/commit/0414c0e2aebdacc8f6df29ce9a3dcec58c13ddba

Graviton 4 is Neoverse-V2. SB-based spin pauses are less disruptive then ISB-based ones on Neoverse-V2.

This PR sets the default value for the OnSpinWaitInst flag to `sb` if the CPU model matches 0xd4f (Neoverse-V2); otherwise, it remains `isb`.
