### PR TITLE
Skipping library noexecstack bit set check for "jfrconv"

### DIFF
--- a/test/hotspot/jtreg/runtime/execstack/TestCheckJDK.java
+++ b/test/hotspot/jtreg/runtime/execstack/TestCheckJDK.java
@@ -48,7 +48,7 @@ public class TestCheckJDK {
     static void checkExecStack(Path file) {
         String filename = file.toString();
         Path parent = file.getParent();
-        if ((parent.endsWith("bin") && !filename.endsWith(".diz")) || filename.endsWith(".so")) {
+        if ((parent.endsWith("bin") && !filename.endsWith(".diz") && !filename.equals("jfrconv")) || filename.endsWith(".so")) {
             if (!WB.checkLibSpecifiesNoexecstack(filename)) {
                 System.out.println("Library does not have the noexecstack bit set: " + filename);
                 testPassed = false;


### PR DESCRIPTION
Skipping noexecstack bit validation for "jfrconv" - file is a shell script wrapper with embedded JAR, not a standard ELF binary. The "jfrconv" file is part of the async profiler integration.