### PR TITLE
Remove french characters from test library class HttpServerAdapters.java

### DIFF
--- a/test/jdk/java/net/httpclient/lib/jdk/httpclient/test/lib/common/HttpServerAdapters.java
+++ b/test/jdk/java/net/httpclient/lib/jdk/httpclient/test/lib/common/HttpServerAdapters.java
@@ -434,7 +434,7 @@ public interface HttpServerAdapters {
     public static class HttpHeadOrGetHandler implements HttpTestHandler {
         final String responseBody;
         public HttpHeadOrGetHandler() {
-            this("pâté de tête persillé");
+            this("pate de tete persille");
         }
         public HttpHeadOrGetHandler(String responseBody) {
             this.responseBody = Objects.requireNonNull(responseBody);


### PR DESCRIPTION
Thank you for taking the time to help improve OpenJDK and Corretto.

If your pull request concerns a security vulnerability then please do not file it here.
Instead, report the problem by email to aws-security@amazon.com.
(You can find more information regarding security issues at https://aws.amazon.com/security/vulnerability-reporting/.)

Otherwise, if your pull request concerns OpenJDK
and is not specific to Corretto,
then we ask you to redirect your contribution to the OpenJDK project.
See http://openjdk.java.net/contribute/ for details on how to do that.

If your issue is specific to Corretto,
then you are in the right place.
Please fill in the following information about your pull request.

### Description
[This upstream commit](https://git.openjdk.org/jdk17u-dev/commit/9b71cd68dc750f2996334300e716deec091eda04) introduced some french characters in their backport for fixing an https2 issue. Unfortunately, this broke some of our tests running on very old centos7 images that do not have a UTF-8 locale, which is needed in order to compile this. This change removes those characters so our tests can compile and pass.

### Related issues


### Motivation and context


### How has this been tested?
Testing with GHA. This only updates an unimportant line in test code, essentially zero risk

### Platform information
    Works on OS: [e.g. Amazon Linux 2 only]
    Applies to version: 17.0.17.9.1


### Additional context
