### PR TITLE
Scope down GitHub token permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,7 +48,6 @@ on:
 
 permissions:
   contents: read
-  actions: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -336,6 +335,8 @@ jobs:
   remove-bundles:
     name: 'Remove bundle artifacts'
     runs-on: ubuntu-22.04
+    permissions:
+      actions: write
     if: always()
     needs:
       - build-linux-x64

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,6 +45,11 @@ on:
         description: 'Additional make arguments'
         required: false
 
+
+permissions:
+  contents: read
+  actions: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Thank you for taking the time to help improve OpenJDK and Corretto.

If your pull request concerns a security vulnerability then please do not file it here.
Instead, report the problem by email to aws-security@amazon.com.
(You can find more information regarding security issues at https://aws.amazon.com/security/vulnerability-reporting/.)

Otherwise, if your pull request concerns OpenJDK
and is not specific to Corretto,
then we ask you to redirect your contribution to the OpenJDK project.
See http://openjdk.java.net/contribute/ for details on how to do that.

If your issue is specific to Corretto,
then you are in the right place.
Please fill in the following information about your pull request.

### Description

Scope down GitHub token permissions for `main.yml` workflow.

### Related issues


### Motivation and context

Improve GitHub Actions security posture.

### How has this been tested?


### Platform information
    Works on OS: [e.g. Amazon Linux 2 only]
    Applies to version [e.g. "11.0.1+13-1" (see output from "java -version")]


### Additional context
