### PR TITLE
8372543: Shenandoah: undercalculated the available size when soft max takes effect

### DIFF
--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAdaptiveHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAdaptiveHeuristics.cpp
@@ -196,31 +196,34 @@ static double saturate(double value, double min, double max) {
 }
 
 bool ShenandoahAdaptiveHeuristics::should_start_gc() {
-  ShenandoahHeap* heap = ShenandoahHeap::heap();
-  size_t max_capacity = heap->max_capacity();
-  size_t capacity = heap->soft_max_capacity();
-  size_t available = heap->free_set()->available();
-  size_t allocated = heap->bytes_allocated_since_gc_start();
-
-  // Make sure the code below treats available without the soft tail.
-  size_t soft_tail = max_capacity - capacity;
-  available = (available > soft_tail) ? (available - soft_tail) : 0;
-
-  // Track allocation rate even if we decide to start a cycle for other reasons.
-  double rate = _allocation_rate.sample(allocated);
   _last_trigger = OTHER;
 
-  size_t min_threshold = capacity / 100 * ShenandoahMinFreeThreshold;
+  ShenandoahHeap* heap = ShenandoahHeap::heap();
+  size_t max_capacity = heap->max_capacity();
+  size_t soft_max_capacity = heap->soft_max_capacity();
+  size_t soft_mutator_capacity = soft_max_capacity * (100.0 - ShenandoahEvacReserve) / 100;
+
+  size_t allocated = heap->bytes_allocated_since_gc_start();
+  // Track allocation rate even if we decide to start a cycle for other reasons.
+  double rate = _allocation_rate.sample(allocated);
+
+  size_t used = heap->free_set()->used();
+  size_t available = (soft_mutator_capacity > used) ? soft_mutator_capacity - used : 0;
+  size_t min_threshold = soft_max_capacity / 100 * ShenandoahMinFreeThreshold;
+
   if (available < min_threshold) {
-    log_info(gc)("Trigger: Free (" SIZE_FORMAT "%s) is below minimum threshold (" SIZE_FORMAT "%s)",
-                 byte_size_in_proper_unit(available),     proper_unit_for_byte_size(available),
-                 byte_size_in_proper_unit(min_threshold), proper_unit_for_byte_size(min_threshold));
+    log_debug(gc, ergo)("should_start_gc calculation: available: " PROPERFMT ", soft_max_capacity: "  PROPERFMT ", "
+              "allocated_since_gc_start: "  PROPERFMT,
+              PROPERFMTARGS(available), PROPERFMTARGS(soft_max_capacity), PROPERFMTARGS(allocated));
+
+    log_info(gc)("Trigger: Free (Soft) (" PROPERFMT ") is below minimum threshold (" PROPERFMT ")",
+                 PROPERFMTARGS(available), PROPERFMTARGS(min_threshold));
     return true;
   }
 
   const size_t max_learn = ShenandoahLearningSteps;
   if (_gc_times_learned < max_learn) {
-    size_t init_threshold = capacity / 100 * ShenandoahInitFreeThreshold;
+    size_t init_threshold = soft_max_capacity / 100 * ShenandoahInitFreeThreshold;
     if (available < init_threshold) {
       log_info(gc)("Trigger: Learning " SIZE_FORMAT " of " SIZE_FORMAT ". Free (" SIZE_FORMAT "%s) is below initial threshold (" SIZE_FORMAT "%s)",
                    _gc_times_learned + 1, max_learn,
@@ -235,8 +238,8 @@ bool ShenandoahAdaptiveHeuristics::should_start_gc() {
   //   2. Accumulated penalties from Degenerated and Full GC
   size_t allocation_headroom = available;
 
-  size_t spike_headroom = capacity / 100 * ShenandoahAllocSpikeFactor;
-  size_t penalties      = capacity / 100 * _gc_time_penalties;
+  size_t spike_headroom = soft_max_capacity / 100 * ShenandoahAllocSpikeFactor;
+  size_t penalties      = soft_max_capacity / 100 * _gc_time_penalties;
 
   allocation_headroom -= MIN2(allocation_headroom, spike_headroom);
   allocation_headroom -= MIN2(allocation_headroom, penalties);

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahCompactHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahCompactHeuristics.cpp
@@ -46,25 +46,27 @@ ShenandoahCompactHeuristics::ShenandoahCompactHeuristics() : ShenandoahHeuristic
 
 bool ShenandoahCompactHeuristics::should_start_gc() {
   ShenandoahHeap* heap = ShenandoahHeap::heap();
-
+  size_t allocated = heap->bytes_allocated_since_gc_start();
   size_t max_capacity = heap->max_capacity();
-  size_t capacity = heap->soft_max_capacity();
-  size_t available = heap->free_set()->available();
+  size_t soft_max_capacity = heap->soft_max_capacity();
+  size_t soft_mutator_capacity = soft_max_capacity * (100.0 - ShenandoahEvacReserve) / 100;
 
-  // Make sure the code below treats available without the soft tail.
-  size_t soft_tail = max_capacity - capacity;
-  available = (available > soft_tail) ? (available - soft_tail) : 0;
-
-  size_t threshold_bytes_allocated = capacity / 100 * ShenandoahAllocationThreshold;
-  size_t min_threshold = capacity / 100 * ShenandoahMinFreeThreshold;
+  size_t used = heap->free_set()->used();
+  size_t available = (soft_mutator_capacity > used) ? soft_mutator_capacity - used : 0;
+  size_t min_threshold = soft_max_capacity / 100 * ShenandoahMinFreeThreshold;
 
   if (available < min_threshold) {
-    log_info(gc)("Trigger: Free (" SIZE_FORMAT "%s) is below minimum threshold (" SIZE_FORMAT "%s)",
-                 byte_size_in_proper_unit(available),     proper_unit_for_byte_size(available),
-                 byte_size_in_proper_unit(min_threshold), proper_unit_for_byte_size(min_threshold));
+    log_debug(gc, ergo)("should_start_gc calculation: available: " PROPERFMT ", soft_max_capacity: "  PROPERFMT ", "
+                  "allocated_since_gc_start: "  PROPERFMT,
+                  PROPERFMTARGS(available), PROPERFMTARGS(soft_max_capacity), PROPERFMTARGS(allocated));
+
+
+    log_info(gc)("Trigger: Free (Soft) (" PROPERFMT ") is below minimum threshold (" PROPERFMT ")",
+                 PROPERFMTARGS(available), PROPERFMTARGS(min_threshold));
     return true;
   }
 
+  size_t threshold_bytes_allocated = soft_max_capacity / 100 * ShenandoahAllocationThreshold;
   size_t bytes_allocated = heap->bytes_allocated_since_gc_start();
   if (bytes_allocated > threshold_bytes_allocated) {
     log_info(gc)("Trigger: Allocated since last cycle (" SIZE_FORMAT "%s) is larger than allocation threshold (" SIZE_FORMAT "%s)",

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahStaticHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahStaticHeuristics.cpp
@@ -41,21 +41,23 @@ ShenandoahStaticHeuristics::~ShenandoahStaticHeuristics() {}
 
 bool ShenandoahStaticHeuristics::should_start_gc() {
   ShenandoahHeap* heap = ShenandoahHeap::heap();
+  size_t allocated = heap->bytes_allocated_since_gc_start();
 
   size_t max_capacity = heap->max_capacity();
-  size_t capacity = heap->soft_max_capacity();
-  size_t available = heap->free_set()->available();
+  size_t soft_max_capacity = heap->soft_max_capacity();
+  size_t soft_mutator_capacity = soft_max_capacity * (100.0 - ShenandoahEvacReserve) / 100;
 
-  // Make sure the code below treats available without the soft tail.
-  size_t soft_tail = max_capacity - capacity;
-  available = (available > soft_tail) ? (available - soft_tail) : 0;
+  size_t used = heap->free_set()->used();
+  size_t available = (soft_mutator_capacity > used) ? soft_mutator_capacity - used : 0;
+  size_t min_threshold = soft_max_capacity / 100 * ShenandoahMinFreeThreshold;
 
-  size_t threshold_available = capacity / 100 * ShenandoahMinFreeThreshold;
+  if (available < min_threshold) {
+    log_debug(gc, ergo)("should_start_gc calculation: available: " PROPERFMT ", soft_max_capacity: "  PROPERFMT ", "
+              "allocated_since_gc_start: "  PROPERFMT,
+              PROPERFMTARGS(available), PROPERFMTARGS(soft_max_capacity), PROPERFMTARGS(allocated));
 
-  if (available < threshold_available) {
-    log_info(gc)("Trigger: Free (" SIZE_FORMAT "%s) is below minimum threshold (" SIZE_FORMAT "%s)",
-                 byte_size_in_proper_unit(available),           proper_unit_for_byte_size(available),
-                 byte_size_in_proper_unit(threshold_available), proper_unit_for_byte_size(threshold_available));
+    log_info(gc)("Trigger: Free (Soft) (" PROPERFMT ") is below minimum threshold (" PROPERFMT ")",
+                 PROPERFMTARGS(available), PROPERFMTARGS(min_threshold));
     return true;
   }
   return ShenandoahHeuristics::should_start_gc();

--- a/test/hotspot/jtreg/gc/shenandoah/TestSoftMaxHeapSizeAvailableCalc.java
+++ b/test/hotspot/jtreg/gc/shenandoah/TestSoftMaxHeapSizeAvailableCalc.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/**
+ * @test id=satb-adaptive
+ * @requires vm.gc.Shenandoah
+ * @library /test/lib
+ * @bug 8372543
+ * @summary When soft max heap size < Xmx, we had a bug reported in JBS-8372543 where available size was undercalculated.
+ *          This caused excessive GC runs.
+ *
+ * @run main/othervm -XX:SoftMaxHeapSize=512m -Xmx2g -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
+ *      -XX:+UseShenandoahGC -Xlog:gc=info
+ *      -XX:ShenandoahGCMode=satb
+ *      -XX:+ShenandoahDegeneratedGC
+ *      -XX:ShenandoahGCHeuristics=adaptive
+ *      TestSoftMaxHeapSizeAvailableCalc
+ */
+
+/**
+ * @test id=satb-static
+ * @requires vm.gc.Shenandoah
+ * @library /test/lib
+ *
+ * @run main/othervm -XX:SoftMaxHeapSize=512m -Xmx2g -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
+ *      -XX:+UseShenandoahGC -Xlog:gc=info
+ *      -XX:ShenandoahGCMode=satb
+ *      -XX:+ShenandoahDegeneratedGC
+ *      -XX:ShenandoahGCHeuristics=static
+ *      TestSoftMaxHeapSizeAvailableCalc
+ */
+
+import java.lang.management.ManagementFactory;
+
+import jdk.test.lib.Asserts;
+import jdk.test.lib.Utils;
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+import jdk.test.lib.dcmd.PidJcmdExecutor;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Random;
+
+import com.sun.management.GarbageCollectorMXBean;
+
+public class TestSoftMaxHeapSizeAvailableCalc {
+    public static void main(String[] args) throws Exception {
+        Allocate.test();
+    }
+
+    // This test runs an app that has a stable heap of ~300M and allocates temporary garbage at ~100M/s
+    // Soft max: 512M, ShenandoahMinFreeThreshold: 10 (default), ShenandoahEvacReserve: 5 (default)
+    // Soft max for mutator: 512M * (100.0 - 5) / 100 = 486.4M
+    // Threshold to trigger gc: 486.4M - 512 * 10 / 100.0 = 435.2M, just above (300 + 100)M.
+    // Expect gc count to be less than 1 / sec.
+    public static class Allocate {
+        static final List<byte[]> longLived = new ArrayList<>();
+
+        public static void test() throws Exception {
+            final int expectedMaxGcCount = Integer.getInteger("expectedMaxGcCount", 30);
+            List<java.lang.management.GarbageCollectorMXBean> collectors = ManagementFactory.getGarbageCollectorMXBeans();
+            java.lang.management.GarbageCollectorMXBean cycleCollector = null;
+            for (java.lang.management.GarbageCollectorMXBean bean : collectors) {
+                if (bean.getName().contains("Cycles")) {
+                    cycleCollector = bean;
+                }
+            }
+
+            // Allocate ~300MB of long-lived objects
+            for (int i = 0; i < 300; i++) {
+                longLived.add(new byte[1_000_000]);
+            }
+
+            // allocate short-lived garbage to the heap
+            long end = System.currentTimeMillis() + 30_000; // 30 seconds
+
+            while (System.currentTimeMillis() < end) {
+                byte[] garbage = new byte[1_000_000];
+                garbage[0] = 1; // prevent optimization
+
+                Thread.sleep(10); // Pace to generate garbage at speed of ~100M/s
+            }
+
+            long gcCount = cycleCollector.getCollectionCount();
+            Asserts.assertLessThan(gcCount, (long) expectedMaxGcCount, "GC was triggered too many times. Expected to be less than: " + expectedMaxGcCount + ", triggered: " + gcCount);
+        }
+    }
+}


### PR DESCRIPTION
Thank you for taking the time to help improve OpenJDK and Corretto.

If your pull request concerns a security vulnerability then please do not file it here.
Instead, report the problem by email to aws-security@amazon.com.
(You can find more information regarding security issues at https://aws.amazon.com/security/vulnerability-reporting/.)

Otherwise, if your pull request concerns OpenJDK
and is not specific to Corretto,
then we ask you to redirect your contribution to the OpenJDK project.
See http://openjdk.java.net/contribute/ for details on how to do that.

If your issue is specific to Corretto,
then you are in the right place.
Please fill in the following information about your pull request.

### Description
- Tip pr: https://github.com/openjdk/jdk/pull/28622.
- Taking the change to corretto early for an internal customer. We want to have a release for them before EOY. 17 is quite different from the tip, but the core math of available size is the same. Will create another one for 21.



### Related issues
https://bugs.openjdk.org/browse/JDK-8372543

### Motivation and context
Excessive unnecessary GCs will be triggered due to we undercalculate the available size when soft max is less than Xmx. Details see [JDK-8372543](https://bugs.openjdk.org/browse/JDK-8372543)

### How has this been tested?
- Ran the new jtreg TestSoftMaxHeapSizeAvailableCalc locally. Without the fix, 40 times of gc in 20 sec. With the fix, 9 times of gc.
- GHA pending


### Platform information
    Works on OS: [e.g. Amazon Linux 2 only]
    Applies to version [e.g. "11.0.1+13-1" (see output from "java -version")]


### Additional context
