### PR TITLE
Using test IP address in AbstractConnectTimeout.java

### DIFF
--- a/test/jdk/java/net/httpclient/AbstractConnectTimeout.java
+++ b/test/jdk/java/net/httpclient/AbstractConnectTimeout.java
@@ -83,7 +83,7 @@ public abstract class AbstractConnectTimeout {
     }
 
     static final ProxySelector EXAMPLE_DOT_COM_PROXY = ProxySelector.of(
-            InetSocketAddress.createUnresolved("example.com", 8080));
+            InetSocketAddress.createUnresolved("203.0.113.1", 8080));
 
     //@Test(dataProvider = "variants")
     protected void timeoutNoProxySync(Version requestVersion,

--- a/test/jdk/java/net/httpclient/AbstractConnectTimeout.java
+++ b/test/jdk/java/net/httpclient/AbstractConnectTimeout.java
@@ -82,6 +82,7 @@ public abstract class AbstractConnectTimeout {
         return l.stream().toArray(Object[][]::new);
     }
 
+    // Using test IP from TEST-NET-3: https://www.rfc-editor.org/rfc/rfc5735
     static final ProxySelector EXAMPLE_DOT_COM_PROXY = ProxySelector.of(
             InetSocketAddress.createUnresolved("203.0.113.1", 8080));
 


### PR DESCRIPTION
After seeing the dependent proxy tests failing when run with EC2, adjusting test logic to explicitly use IP reserved for testing. Fix works on Windows, Linux, and MacOS testing.