### PR TITLE
Fixing alpine legal file permissions

### DIFF
--- a/installers/linux/alpine/tar/build.gradle
+++ b/installers/linux/alpine/tar/build.gradle
@@ -185,7 +185,7 @@ task packageBuildResults(type: Tar) {
     from("${jdkResultingImage}/legal") {
         include '**'
         fileMode 0444
-        into "amazon-corretto-${project.version.full}-alpine-linux-${arch_alias}/legal"
+        into "legal"
     }
     into "amazon-corretto-${project.version.full}-alpine-linux-${arch_alias}"
 }

--- a/installers/linux/alpine/tar/build.gradle
+++ b/installers/linux/alpine/tar/build.gradle
@@ -174,11 +174,18 @@ task packageBuildResults(type: Tar) {
         include 'conf/**'
         include 'include/**'
         include 'jmods/**'
-        include 'legal/**'
         include 'lib/**'
         include 'man/man1/**'
         include 'release'
         exclude '**/*.diz'
+    }
+
+    // Copy legal directory specifically to set permission correctly.
+    // See https://github.com/corretto/corretto-11/issues/129
+    from("${jdkResultingImage}/legal") {
+        include '**'
+        fileMode 0444
+        into "amazon-corretto-${project.version.full}-alpine-linux-${arch_alias}/legal"
     }
     into "amazon-corretto-${project.version.full}-alpine-linux-${arch_alias}"
 }


### PR DESCRIPTION
### Overview
Alpine permissions for legal files are technically broader than they need to be. If testing with a non-root user, a umask of 0022 will be applied when uncompressing the artifact, leading to 755 permissions. However, if using a root user when uncompressing, no umask is applied and we'll see the true 777 permissions.

This change pulls in the logic from the existing linux `build.gradle` file. It also scopes down permissions further to 444 (as done by the "universal" linux tar logic.

Note: this change is not applicable to newer versions (which use different logic to handle legal permissions).